### PR TITLE
Refactor Flickr image hosting facade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.flickr4java</groupId>
             <artifactId>flickr4java</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.11</version>
         </dependency>
 
         <dependency>
@@ -177,6 +177,18 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <release>${java.version}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-configuration-processor</artifactId>
+                            <version>${project.parent.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/legohunter/imaging/flickr/api/FlickrPhotoService.java
+++ b/src/main/java/io/legohunter/imaging/flickr/api/FlickrPhotoService.java
@@ -1,13 +1,6 @@
 package io.legohunter.imaging.flickr.api;
 
-import com.flickr4java.flickr.photos.Photo;
-import com.flickr4java.flickr.photosets.Photoset;
-import io.legohunter.imaging.model.AlbumManifest;
-import io.legohunter.imaging.model.PhotoServiceRequest;
-import io.legohunter.imaging.model.PhotoServiceResponse;
+import io.legohunter.imaging.service.hosting.api.ImageHostingService;
 
-public interface FlickrPhotoService {
-    PhotoServiceResponse<Photoset> createAlbum(PhotoServiceRequest<AlbumManifest> request);
-
-    PhotoServiceResponse<Photo> getPhoto(PhotoServiceRequest<String> request);
+public interface FlickrPhotoService extends ImageHostingService {
 }

--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -1,31 +1,90 @@
 package io.legohunter.imaging.flickr.impl;
 
+import com.flickr4java.flickr.Flickr;
 import com.flickr4java.flickr.FlickrException;
 import com.flickr4java.flickr.photos.Photo;
 import com.flickr4java.flickr.photos.PhotosInterface;
 import com.flickr4java.flickr.photosets.Photoset;
 import com.flickr4java.flickr.photosets.PhotosetsInterface;
+import com.flickr4java.flickr.uploader.IUploader;
+import com.flickr4java.flickr.uploader.UploadMetaData;
 import io.legohunter.imaging.exception.LegoImagingException;
-import io.legohunter.imaging.model.AlbumManifest;
-import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.flickr.api.FlickrPhotoService;
+import io.legohunter.imaging.flickr.model.FlickrServiceResponse;
+import io.legohunter.imaging.model.AlbumManifest;
+import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
+import io.legohunter.imaging.model.HostedPhoto;
+import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceRequest;
 import io.legohunter.imaging.model.PhotoServiceResponse;
-import io.legohunter.imaging.flickr.model.FlickrServiceResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class FlickrPhotoServiceImpl implements FlickrPhotoService {
+    private static final boolean SYNC_UPLOAD = false;
+    private static final String JPEG_MIME_TYPE = "image/jpeg";
+
+    private final IUploader uploader;
     private final PhotosetsInterface photosetsInterface;
     private final PhotosInterface photosInterface;
 
     @Override
-    public PhotoServiceResponse<Photoset> createAlbum(PhotoServiceRequest<AlbumManifest> request) throws LegoImagingException {
-        PhotoServiceResponse<Photoset> response;
+    public PhotoServiceResponse<String> uploadPhoto(PhotoServiceRequest<PhotoMetaDataV1> request) {
+        PhotoServiceResponse<String> response;
+        PhotoMetaDataV1 photoMetaData = request.get();
+        try {
+            String photoId = uploader.upload(Files.readAllBytes(photoMetaData.getAbsolutePath()), uploadMetaData(photoMetaData));
+            response = new FlickrServiceResponse<>(photoId);
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        } catch (IOException e) {
+            response = new FlickrServiceResponse<>(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<String> replacePhoto(PhotoServiceRequest<PhotoMetaDataV1> request) {
+        PhotoServiceResponse<String> response;
+        PhotoMetaDataV1 photoMetaData = request.get();
+        try {
+            String photoId = uploader.replace(Files.readAllBytes(photoMetaData.getAbsolutePath()), photoMetaData.getPhotoId(), SYNC_UPLOAD);
+            response = new FlickrServiceResponse<>(photoId);
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        } catch (IOException e) {
+            response = new FlickrServiceResponse<>(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<Void> deletePhoto(PhotoServiceRequest<String> request) {
+        PhotoServiceResponse<Void> response;
+        try {
+            photosInterface.delete(request.get());
+            response = new FlickrServiceResponse<>((Void) null);
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<AlbumManifest> request) throws LegoImagingException {
+        PhotoServiceResponse<HostedAlbum> response;
         AlbumManifest albumManifest = request.get();
         try {
             if (albumManifest.getPhotos().size() < 1) {
@@ -33,25 +92,69 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
             }
             PhotoMetaDataV1 primaryPhoto = albumManifest.getPrimaryPhoto();
             Photoset photoset = photosetsInterface.create(albumManifest.getTitle(), albumManifest.getDescription(), primaryPhoto.getPhotoId());
-            response = new FlickrServiceResponse<>(photoset);
+            response = new FlickrServiceResponse<>(HostedAlbum.builder()
+                    .id(photoset.getId())
+                    .url(photoset.getUrl())
+                    .build());
         } catch (FlickrException e) {
-            response = new FlickrServiceResponse<>(e, e.getErrorCode(), e.getErrorMessage());
+            response = flickrError(e);
         }
         log.debug("Flickr Response [{}]", response);
         return response;
     }
 
     @Override
-    public PhotoServiceResponse<Photo> getPhoto(PhotoServiceRequest<String> request) {
-        PhotoServiceResponse<Photo> response;
-        String photoId = request.get();
+    public PhotoServiceResponse<Void> updateAlbumMembership(PhotoServiceRequest<HostedAlbumMembershipRequest> request) {
+        PhotoServiceResponse<Void> response;
+        HostedAlbumMembershipRequest membershipRequest = request.get();
         try {
-            Photo photo = photosInterface.getPhoto(photoId);
-            response = new FlickrServiceResponse<>(photo);
+            photosetsInterface.editPhotos(
+                    membershipRequest.getAlbumId(),
+                    membershipRequest.getPrimaryPhotoId(),
+                    membershipRequest.getPhotoIds().toArray(String[]::new));
+            response = new FlickrServiceResponse<>((Void) null);
         } catch (FlickrException e) {
-            response = new FlickrServiceResponse<>(e, e.getErrorCode(), e.getErrorMessage());
+            response = flickrError(e);
         }
         log.debug("Flickr Response [{}]", response);
         return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<HostedPhoto> getPhoto(PhotoServiceRequest<String> request) {
+        PhotoServiceResponse<HostedPhoto> response;
+        String photoId = request.get();
+        try {
+            Photo photo = photosInterface.getPhoto(photoId);
+            response = new FlickrServiceResponse<>(HostedPhoto.builder()
+                    .id(photo.getId())
+                    .title(photo.getTitle())
+                    .build());
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    private UploadMetaData uploadMetaData(PhotoMetaDataV1 photoMetaData) {
+        UploadMetaData uploadMetaData = new UploadMetaData();
+        uploadMetaData.setAsync(SYNC_UPLOAD);
+        uploadMetaData.setContentType(Flickr.CONTENTTYPE_PHOTO);
+        uploadMetaData.setFamilyFlag(false);
+        uploadMetaData.setFilemimetype(JPEG_MIME_TYPE);
+        uploadMetaData.setFilename(photoMetaData.getFilename().toString());
+        uploadMetaData.setDescription("Description [" + photoMetaData.getFilename() + "]");
+        uploadMetaData.setFriendFlag(false);
+        uploadMetaData.setHidden(false);
+        uploadMetaData.setPublicFlag(true);
+        uploadMetaData.setSafetyLevel(Flickr.SAFETYLEVEL_SAFE);
+        uploadMetaData.setTags(Collections.emptyList());
+        uploadMetaData.setTitle("Title [" + photoMetaData.getFilename() + "]");
+        return uploadMetaData;
+    }
+
+    private <T> PhotoServiceResponse<T> flickrError(FlickrException e) {
+        return new FlickrServiceResponse<>(e, e.getErrorCode(), e.getErrorMessage());
     }
 }

--- a/src/main/java/io/legohunter/imaging/flickr/model/CreatePhotoSetResponse.java
+++ b/src/main/java/io/legohunter/imaging/flickr/model/CreatePhotoSetResponse.java
@@ -1,10 +1,10 @@
 package io.legohunter.imaging.flickr.model;
 
-import com.flickr4java.flickr.photosets.Photoset;
+import io.legohunter.imaging.model.HostedAlbum;
 
-public class CreatePhotoSetResponse extends FlickrServiceResponse<Photoset> {
-    public CreatePhotoSetResponse(Photoset photoset) {
-        super(photoset);
+public class CreatePhotoSetResponse extends FlickrServiceResponse<HostedAlbum> {
+    public CreatePhotoSetResponse(HostedAlbum album) {
+        super(album);
     }
 
     public CreatePhotoSetResponse(Exception e, String errorCode, String errorMessage) {

--- a/src/main/java/io/legohunter/imaging/flickr/model/FlickrServiceResponse.java
+++ b/src/main/java/io/legohunter/imaging/flickr/model/FlickrServiceResponse.java
@@ -5,6 +5,8 @@ import io.legohunter.imaging.model.PhotoServiceResponse;
 import java.util.Optional;
 
 public class FlickrServiceResponse<T> implements PhotoServiceResponse<T> {
+    public static final String INTERNAL_ERROR_CODE = "-1";
+
     private T t;
     private Exception e;
     private String errorCode;
@@ -20,6 +22,10 @@ public class FlickrServiceResponse<T> implements PhotoServiceResponse<T> {
         this.e = e;
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
+    }
+
+    public FlickrServiceResponse(Exception e) {
+        this(e, INTERNAL_ERROR_CODE, e.getMessage());
     }
 
     @Override

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbum.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbum.java
@@ -1,0 +1,11 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class HostedAlbum {
+    private String id;
+    private String url;
+}

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbumMembershipRequest.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbumMembershipRequest.java
@@ -1,0 +1,14 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Set;
+
+@Data
+@Builder
+public class HostedAlbumMembershipRequest {
+    private String albumId;
+    private String primaryPhotoId;
+    private Set<String> photoIds;
+}

--- a/src/main/java/io/legohunter/imaging/model/HostedPhoto.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedPhoto.java
@@ -1,0 +1,11 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class HostedPhoto {
+    private String id;
+    private String title;
+}

--- a/src/main/java/io/legohunter/imaging/model/SimplePhotoServiceRequest.java
+++ b/src/main/java/io/legohunter/imaging/model/SimplePhotoServiceRequest.java
@@ -1,0 +1,13 @@
+package io.legohunter.imaging.model;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SimplePhotoServiceRequest<T> implements PhotoServiceRequest<T> {
+    private final T value;
+
+    @Override
+    public T get() {
+        return value;
+    }
+}

--- a/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
+++ b/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
@@ -1,0 +1,23 @@
+package io.legohunter.imaging.service.hosting.api;
+
+import io.legohunter.imaging.model.AlbumManifest;
+import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
+import io.legohunter.imaging.model.HostedPhoto;
+import io.legohunter.imaging.model.PhotoMetaDataV1;
+import io.legohunter.imaging.model.PhotoServiceRequest;
+import io.legohunter.imaging.model.PhotoServiceResponse;
+
+public interface ImageHostingService {
+    PhotoServiceResponse<String> uploadPhoto(PhotoServiceRequest<PhotoMetaDataV1> request);
+
+    PhotoServiceResponse<String> replacePhoto(PhotoServiceRequest<PhotoMetaDataV1> request);
+
+    PhotoServiceResponse<Void> deletePhoto(PhotoServiceRequest<String> request);
+
+    PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<AlbumManifest> request);
+
+    PhotoServiceResponse<Void> updateAlbumMembership(PhotoServiceRequest<HostedAlbumMembershipRequest> request);
+
+    PhotoServiceResponse<HostedPhoto> getPhoto(PhotoServiceRequest<String> request);
+}

--- a/src/main/java/io/legohunter/imaging/service/upload/impl/PhotoServiceUploadManagerImpl.java
+++ b/src/main/java/io/legohunter/imaging/service/upload/impl/PhotoServiceUploadManagerImpl.java
@@ -1,33 +1,30 @@
 package io.legohunter.imaging.service.upload.impl;
 
-import com.flickr4java.flickr.Flickr;
-import com.flickr4java.flickr.FlickrException;
-import com.flickr4java.flickr.photosets.Photoset;
-import com.flickr4java.flickr.photosets.PhotosetsInterface;
-import com.flickr4java.flickr.uploader.IUploader;
-import com.flickr4java.flickr.uploader.UploadMetaData;
 import io.legohunter.imaging.config.LegoImagingProperties;
 import io.legohunter.imaging.exception.LegoImagingException;
 import io.legohunter.imaging.model.AlbumManifest;
+import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.bitly.model.bitly.ShortenRequest;
 import io.legohunter.imaging.bitly.impl.BitlinksService;
+import io.legohunter.imaging.model.PhotoServiceResponse;
+import io.legohunter.imaging.model.SimplePhotoServiceRequest;
 import io.legohunter.imaging.service.album.api.AlbumManager;
+import io.legohunter.imaging.service.hosting.api.ImageHostingService;
 import io.legohunter.imaging.service.upload.api.PhotoServiceUploadManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StopWatch;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -35,8 +32,7 @@ import java.util.Set;
 @Slf4j
 @Configuration
 public class PhotoServiceUploadManagerImpl implements PhotoServiceUploadManager {
-    private final PhotosetsInterface photosetsInterface;
-    private final IUploader uploader;
+    private final ImageHostingService imageHostingService;
     private final LegoImagingProperties legoImagingProperties;
     private final AlbumManager albumManager;
     private final BitlinksService bitlinksService;
@@ -57,45 +53,31 @@ public class PhotoServiceUploadManagerImpl implements PhotoServiceUploadManager 
                                     log.info("Uploading changed photo [{}]", pmd);
                                     StopWatch timer = new StopWatch();
                                     timer.start();
-                                    String response = uploader.replace(Files.readAllBytes(pmd.getAbsolutePath()), pmd.getPhotoId(), false);
+                                    PhotoServiceResponse<String> response = imageHostingService.replacePhoto(new SimplePhotoServiceRequest<>(pmd));
+                                    assertSuccess(response, pmd);
                                     timer.stop();
-                                    pmd.setPhotoId(response);
+                                    pmd.setPhotoId(response.get());
                                     pmd.setChanged(false);
                                     log.info("Uploaded changed photo [{}] in [{}] ms", pmd, timer.getTotalTimeMillis());
                                 } else {
                                     log.debug("Photo not changed [{}]", pmd);
                                 }
                             } else {
-                                UploadMetaData uploadMetaData = new UploadMetaData();
-                                uploadMetaData.setAsync(false);
-                                uploadMetaData.setContentType(Flickr.CONTENTTYPE_PHOTO);
-                                uploadMetaData.setFamilyFlag(false);
-                                uploadMetaData.setFilemimetype("image/jpeg");
-                                uploadMetaData.setFilename(pmd.getFilename()
-                                        .toString());
-                                uploadMetaData.setDescription("Description [" + pmd.getFilename()
-                                        .toString() + "]");
-                                uploadMetaData.setFriendFlag(false);
-                                uploadMetaData.setHidden(false);
-                                uploadMetaData.setPublicFlag(true);
-                                uploadMetaData.setSafetyLevel(Flickr.SAFETYLEVEL_SAFE);
-                                uploadMetaData.setTags(Collections.emptyList());
-                                uploadMetaData.setTitle("Title [" + pmd.getFilename()
-                                        .toString() + "]");
                                 log.info("Uploading new [{}]", pmd);
                                 StopWatch timer = new StopWatch();
                                 timer.start();
-                                String response = uploader.upload(Files.readAllBytes(pmd.getAbsolutePath()), uploadMetaData);
+                                PhotoServiceResponse<String> response = imageHostingService.uploadPhoto(new SimplePhotoServiceRequest<>(pmd));
+                                assertSuccess(response, pmd);
                                 timer.stop();
                                 pmd.setUploadReturnCode(0);
                                 pmd.setUploadedTimeStamp(LocalDateTime.now());
-                                pmd.setPhotoId(response);
+                                pmd.setPhotoId(response.get());
                                 pmd.setChanged(false);
                                 log.info("Uploaded new [{}] in [{}] ms", pmd, timer.getTotalTimeMillis());
                             }
-                        } catch (FlickrException | IOException e) {
+                        } catch (LegoImagingException e) {
                             pmd.setUploadReturnCode(-1);
-                            throw new LegoImagingException(e);
+                            throw e;
                         }
                     });
             // Create the Album if it doesn't exist
@@ -104,26 +86,45 @@ public class PhotoServiceUploadManagerImpl implements PhotoServiceUploadManager 
             String photosetId = Optional.ofNullable(a.getPhotosetId())
                     .orElseGet(() -> {
                         try {
-                            Photoset photoset = photosetsInterface.create(a.getTitle(), a.getDescription(), primaryPhotoId);
-                            log.info("Created Photoset [{}] with primary photo id [{}] - filename [{}]", photoset, primaryPhotoId, primaryPhoto.getFilename());
-                            a.setPhotosetId(photoset.getId());
-                            a.setUrl(new URL(photoset.getUrl()));
+                            PhotoServiceResponse<HostedAlbum> response = imageHostingService.createAlbum(new SimplePhotoServiceRequest<>(a));
+                            assertSuccess(response);
+                            HostedAlbum album = response.get();
+                            log.info("Created Photoset [{}] with primary photo id [{}] - filename [{}]", album, primaryPhotoId, primaryPhoto.getFilename());
+                            a.setPhotosetId(album.getId());
+                            a.setUrl(new URL(album.getUrl()));
                             ShortenRequest shortenRequest = new ShortenRequest();
                             shortenRequest.setLongUrl(a.getUrl().toExternalForm());
                             a.setShortUrl(new URL(bitlinksService.shorten(shortenRequest).getLink()));
                             return a.getPhotosetId();
-                        } catch (MalformedURLException | FlickrException e) {
+                        } catch (MalformedURLException e) {
                             throw new LegoImagingException(e);
                         }
                     });
-            try {
-                photosetsInterface.editPhotos(a.getPhotosetId(), primaryPhotoId, a.getPhotoIdsArray());
+            PhotoServiceResponse<Void> response = imageHostingService.updateAlbumMembership(new SimplePhotoServiceRequest<>(HostedAlbumMembershipRequest.builder()
+                    .albumId(a.getPhotosetId())
+                    .primaryPhotoId(primaryPhotoId)
+                    .photoIds(new LinkedHashSet<>(a.getPhotoIds()))
+                    .build()));
+            if (response.isError()) {
+                log.error(response.responseMessage());
+            } else {
                 log.info("Updated PhotosetId [{}] with primary photo id [{}] - added photos {}", photosetId, primaryPhoto.getPhotoId(), a.getPhotoIdsArray());
-            } catch (FlickrException e) {
-                log.error(e.getMessage(), e);
             }
             AlbumManifest.toJson(a.getAlbumManifestFile(root), a);
         });
         albumManifests.clear();
+    }
+
+    private void assertSuccess(PhotoServiceResponse<?> response, PhotoMetaDataV1 photoMetaData) {
+        if (response.isError()) {
+            photoMetaData.setUploadReturnCode(response.responseCode());
+            throw new LegoImagingException(response.responseMessage());
+        }
+    }
+
+    private void assertSuccess(PhotoServiceResponse<?> response) {
+        if (response.isError()) {
+            throw new LegoImagingException(response.responseMessage());
+        }
     }
 }

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -1,44 +1,178 @@
 package io.legohunter.imaging.flickr.impl;
 
+import com.flickr4java.flickr.Flickr;
+import com.flickr4java.flickr.FlickrException;
+import com.flickr4java.flickr.photos.Photo;
+import com.flickr4java.flickr.photos.PhotosInterface;
+import com.flickr4java.flickr.photosets.Photoset;
+import com.flickr4java.flickr.photosets.PhotosetsInterface;
+import com.flickr4java.flickr.uploader.IUploader;
+import com.flickr4java.flickr.uploader.UploadMetaData;
+import io.legohunter.imaging.flickr.model.FlickrServiceRequest;
+import io.legohunter.imaging.model.AlbumManifest;
+import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
+import io.legohunter.imaging.model.HostedPhoto;
+import io.legohunter.imaging.model.PhotoMetaDataV1;
+import io.legohunter.imaging.model.PhotoServiceResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class FlickrPhotoServiceTest {
+    private IUploader uploader;
+    private PhotosetsInterface photosetsInterface;
+    private PhotosInterface photosInterface;
+    private FlickrPhotoServiceImpl flickrPhotoService;
 
-    @Test
-    void createAlbum() {
-//        FlickrPhotoService flickrPhotoService = new FlickrPhotoService();
-//        AlbumManifest albumManifest = new AlbumManifest();
-//        CreatePhotoSetRequest request = new CreatePhotoSetRequest(albumManifest);
-//        assertThatThrownBy(() -> {
-//            flickrPhotoService.createAlbum(request);
-//        }).isInstanceOf(NotImplementedException.class);
+    @BeforeEach
+    void setUp() {
+        uploader = mock(IUploader.class);
+        photosetsInterface = mock(PhotosetsInterface.class);
+        photosInterface = mock(PhotosInterface.class);
+        flickrPhotoService = new FlickrPhotoServiceImpl(uploader, photosetsInterface, photosInterface);
     }
 
     @Test
-    void updateAlbum() {
+    void uploadPhoto_uploadsFileWithDefaultPhotoMetadata(@TempDir Path tempDir) throws Exception {
+        Path photoPath = tempDir.resolve("photo.jpg");
+        Files.write(photoPath, new byte[]{1, 2, 3});
+        when(uploader.upload(any(byte[].class), any(UploadMetaData.class))).thenReturn("photo-123");
+
+        PhotoServiceResponse<String> response = flickrPhotoService.uploadPhoto(new FlickrServiceRequest<>(new PhotoMetaDataV1(photoPath)));
+
+        assertThat(response.isError()).isFalse();
+        assertThat(response.responseCode()).isZero();
+        assertThat(response.get()).isEqualTo("photo-123");
+        org.mockito.ArgumentCaptor<UploadMetaData> metadataCaptor = org.mockito.ArgumentCaptor.forClass(UploadMetaData.class);
+        verify(uploader).upload(eq(new byte[]{1, 2, 3}), metadataCaptor.capture());
+        UploadMetaData metadata = metadataCaptor.getValue();
+        assertThat(metadata.isAsync()).isFalse();
+        assertThat(metadata.getContentType()).isEqualTo(Flickr.CONTENTTYPE_PHOTO);
+        assertThat(metadata.getFilemimetype()).isEqualTo("image/jpeg");
+        assertThat(metadata.getFilename()).isEqualTo("photo.jpg");
+        assertThat(metadata.isPublicFlag()).isTrue();
+        assertThat(metadata.isFriendFlag()).isFalse();
+        assertThat(metadata.isFamilyFlag()).isFalse();
+        assertThat(metadata.isHidden()).isFalse();
+        assertThat(metadata.getSafetyLevel()).isEqualTo(Flickr.SAFETYLEVEL_SAFE);
+        assertThat(metadata.getTags()).isEmpty();
     }
 
     @Test
-    void addPhotoToAlbum() {
+    void replacePhoto_replacesExistingPhoto(@TempDir Path tempDir) throws Exception {
+        Path photoPath = tempDir.resolve("photo.jpg");
+        Files.write(photoPath, new byte[]{4, 5, 6});
+        PhotoMetaDataV1 photoMetaData = new PhotoMetaDataV1(photoPath);
+        photoMetaData.setPhotoId("existing-photo");
+        when(uploader.replace(any(byte[].class), eq("existing-photo"), eq(false))).thenReturn("replacement-photo");
+
+        PhotoServiceResponse<String> response = flickrPhotoService.replacePhoto(new FlickrServiceRequest<>(photoMetaData));
+
+        assertThat(response.isError()).isFalse();
+        assertThat(response.get()).isEqualTo("replacement-photo");
+        verify(uploader).replace(eq(new byte[]{4, 5, 6}), eq("existing-photo"), eq(false));
     }
 
     @Test
-    void uploadAllAlbumPhotos() {
+    void deletePhoto_deletesPhoto() throws Exception {
+        PhotoServiceResponse<Void> response = flickrPhotoService.deletePhoto(new FlickrServiceRequest<>("photo-123"));
+
+        assertThat(response.isError()).isFalse();
+        verify(photosInterface).delete("photo-123");
     }
 
     @Test
-    void photoIsUpdated() {
+    void createAlbum_createsPhotosetFromAlbumManifest() throws Exception {
+        Photoset photoset = new Photoset();
+        photoset.setId("album-123");
+        photoset.setUrl("https://www.flickr.com/photos/user/albums/album-123");
+        when(photosetsInterface.create("album title", "album description", "primary-photo")).thenReturn(photoset);
+
+        AlbumManifest albumManifest = new AlbumManifest();
+        albumManifest.setTitle("album title");
+        albumManifest.setDescription("album description");
+        albumManifest.setPhotos(List.of(primaryPhoto("primary-photo")));
+
+        PhotoServiceResponse<HostedAlbum> response = flickrPhotoService.createAlbum(new FlickrServiceRequest<>(albumManifest));
+
+        assertThat(response.isError()).isFalse();
+        assertThat(response.get().getId()).isEqualTo("album-123");
+        assertThat(response.get().getUrl()).isEqualTo("https://www.flickr.com/photos/user/albums/album-123");
+        verify(photosetsInterface).create("album title", "album description", "primary-photo");
     }
 
     @Test
-    void loadAlbumManifest() {
+    void updateAlbumMembership_editsPhotosetMembership() throws Exception {
+        HostedAlbumMembershipRequest request = HostedAlbumMembershipRequest.builder()
+                .albumId("album-123")
+                .primaryPhotoId("photo-1")
+                .photoIds(new LinkedHashSet<>(List.of("photo-1", "photo-2")))
+                .build();
+
+        PhotoServiceResponse<Void> response = flickrPhotoService.updateAlbumMembership(new FlickrServiceRequest<>(request));
+
+        assertThat(response.isError()).isFalse();
+        verify(photosetsInterface).editPhotos("album-123", "photo-1", new String[]{"photo-1", "photo-2"});
     }
 
     @Test
-    void saveAlbumManifest() {
+    void getPhoto_mapsFlickrPhoto() throws Exception {
+        Photo photo = new Photo();
+        photo.setId("photo-123");
+        photo.setTitle("Photo Title");
+        when(photosInterface.getPhoto("photo-123")).thenReturn(photo);
+
+        PhotoServiceResponse<HostedPhoto> response = flickrPhotoService.getPhoto(new FlickrServiceRequest<>("photo-123"));
+
+        assertThat(response.isError()).isFalse();
+        assertThat(response.get().getId()).isEqualTo("photo-123");
+        assertThat(response.get().getTitle()).isEqualTo("Photo Title");
     }
 
     @Test
-    void getAlbumPhotoMetaData() {
+    void flickrException_isMappedToErrorResponse(@TempDir Path tempDir) throws Exception {
+        Path photoPath = tempDir.resolve("photo.jpg");
+        Files.write(photoPath, new byte[]{1});
+        when(uploader.upload(any(byte[].class), any(UploadMetaData.class)))
+                .thenThrow(new FlickrException("99", "Insufficient permissions"));
+
+        PhotoServiceResponse<String> response = flickrPhotoService.uploadPhoto(new FlickrServiceRequest<>(new PhotoMetaDataV1(photoPath)));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.responseCode()).isEqualTo(99);
+        assertThat(response.responseMessage()).isEqualTo("Insufficient permissions");
+    }
+
+    @Test
+    void fileReadFailure_isMappedToInternalErrorResponse(@TempDir Path tempDir) {
+        Path missingPhoto = tempDir.resolve("missing.jpg");
+
+        PhotoServiceResponse<String> response = flickrPhotoService.uploadPhoto(new FlickrServiceRequest<>(new PhotoMetaDataV1(missingPhoto)));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.responseCode()).isEqualTo(-1);
+        assertThat(response.responseMessage()).contains("missing.jpg");
+        verifyNoInteractions(uploader);
+    }
+
+    private PhotoMetaDataV1 primaryPhoto(String photoId) {
+        PhotoMetaDataV1 photoMetaData = new PhotoMetaDataV1(Path.of("photo.jpg"));
+        photoMetaData.setPhotoId(photoId);
+        photoMetaData.setPrimary(true);
+        return photoMetaData;
     }
 }


### PR DESCRIPTION
## Summary
- expand the Flickr photo service to cover upload, replace, delete, album creation, album membership updates, and photo lookup
- introduce provider-neutral image hosting contracts and models so upload orchestration depends on `ImageHostingService` rather than Flickr-specific API types
- move direct flickr4java uploader/photoset usage out of `PhotoServiceUploadManagerImpl` and keep flickr4java isolated in the Flickr adapter
- use `Set<String>` for hosted album membership requests, converting to `String[]` only at the flickr4java boundary
- upgrade flickr4java from `3.0.1` to `3.0.11`
- make Lombok annotation processing explicit for Maven/JDK 25 compatibility and ignore generated `target/` output

## Tests
- `mvn -Dtest=FlickrPhotoServiceTest test`
- `mvn test`