### PR TITLE
Flickr Integration Phase 2 - provider metadata updates

### DIFF
--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -15,6 +15,7 @@ import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedPhoto;
+import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceRequest;
 import io.legohunter.imaging.model.PhotoServiceResponse;
@@ -112,6 +113,26 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
                     membershipRequest.getAlbumId(),
                     membershipRequest.getPrimaryPhotoId(),
                     membershipRequest.getPhotoIds().toArray(String[]::new));
+            response = new FlickrServiceResponse<>((Void) null);
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<Void> updatePhotoMetadata(PhotoServiceRequest<HostedPhotoMetadataUpdate> request) {
+        PhotoServiceResponse<Void> response;
+        HostedPhotoMetadataUpdate metadataUpdate = request.get();
+        try {
+            photosInterface.setMeta(
+                    metadataUpdate.getPhotoId(),
+                    metadataUpdate.getTitle(),
+                    metadataUpdate.getDescription());
+            if (metadataUpdate.getTags() != null && !metadataUpdate.getTags().isEmpty()) {
+                photosInterface.setTags(metadataUpdate.getPhotoId(), metadataUpdate.getTags().toArray(String[]::new));
+            }
             response = new FlickrServiceResponse<>((Void) null);
         } catch (FlickrException e) {
             response = flickrError(e);

--- a/src/main/java/io/legohunter/imaging/metadata/MetadataFingerprintService.java
+++ b/src/main/java/io/legohunter/imaging/metadata/MetadataFingerprintService.java
@@ -1,0 +1,77 @@
+package io.legohunter.imaging.metadata;
+
+import io.legohunter.imaging.metadata.model.ConditionEnum;
+import io.legohunter.imaging.metadata.model.ImageMetadata;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+import java.util.StringJoiner;
+
+@Component
+public class MetadataFingerprintService {
+    private static final String HASH_ALGORITHM = "SHA-256";
+    private static final String VERSION = "v1";
+
+    public String calculateHash(ImageMetadata metadata) {
+        if (metadata == null) {
+            throw new IllegalArgumentException("metadata is required");
+        }
+
+        return sha256Hex(canonicalMetadata(metadata));
+    }
+
+    private String canonicalMetadata(ImageMetadata metadata) {
+        StringJoiner fields = new StringJoiner("\n");
+        fields.add(VERSION);
+        fields.add("uuid=" + normalizeIdentifier(metadata.uuid()));
+        fields.add("externalItemNumber=" + normalizeText(metadata.externalItemNumber()));
+        fields.add("primary=" + normalizeBoolean(metadata.primary()));
+        fields.add("sealed=" + normalizeBoolean(metadata.sealed()));
+        fields.add("builtOnce=" + normalizeBoolean(metadata.builtOnce()));
+        fields.add("boxCondition=" + normalizeCondition(metadata.boxCondition()));
+        fields.add("instructionsCondition=" + normalizeCondition(metadata.instructionsCondition()));
+        fields.add("itemCondition=" + normalizeCondition(metadata.itemCondition()));
+        fields.add("caption=" + normalizeText(metadata.caption()));
+        return fields.toString();
+    }
+
+    private String normalizeIdentifier(String value) {
+        return normalizeText(value).toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeText(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+
+        return value.trim();
+    }
+
+    private String normalizeBoolean(Boolean value) {
+        return value == null ? "" : value.toString();
+    }
+
+    private String normalizeCondition(ConditionEnum condition) {
+        return condition == null ? "" : condition.name();
+    }
+
+    private String sha256Hex(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(HASH_ALGORITHM);
+            return bytesToHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder hex = new StringBuilder(bytes.length * 2);
+        for (byte currentByte : bytes) {
+            hex.append(String.format("%02x", currentByte));
+        }
+        return hex.toString();
+    }
+}

--- a/src/main/java/io/legohunter/imaging/model/HostedPhotoMetadataUpdate.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedPhotoMetadataUpdate.java
@@ -1,0 +1,18 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import java.util.List;
+
+@Data
+@Builder
+public class HostedPhotoMetadataUpdate {
+    private String photoId;
+    private String title;
+    private String description;
+
+    @Singular
+    private List<String> tags;
+}

--- a/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
+++ b/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
@@ -4,6 +4,7 @@ import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedPhoto;
+import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceRequest;
 import io.legohunter.imaging.model.PhotoServiceResponse;
@@ -18,6 +19,8 @@ public interface ImageHostingService {
     PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<AlbumManifest> request);
 
     PhotoServiceResponse<Void> updateAlbumMembership(PhotoServiceRequest<HostedAlbumMembershipRequest> request);
+
+    PhotoServiceResponse<Void> updatePhotoMetadata(PhotoServiceRequest<HostedPhotoMetadataUpdate> request);
 
     PhotoServiceResponse<HostedPhoto> getPhoto(PhotoServiceRequest<String> request);
 }

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -13,6 +13,7 @@ import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedPhoto;
+import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,6 +28,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -127,6 +129,41 @@ class FlickrPhotoServiceTest {
 
         assertThat(response.isError()).isFalse();
         verify(photosetsInterface).editPhotos("album-123", "photo-1", new String[]{"photo-1", "photo-2"});
+    }
+
+    @Test
+    void updatePhotoMetadata_setsMetaAndTags() throws Exception {
+        HostedPhotoMetadataUpdate request = HostedPhotoMetadataUpdate.builder()
+                .photoId("photo-123")
+                .title("Front view")
+                .description("Photo description")
+                .tag("lego")
+                .tag("sealed")
+                .build();
+
+        PhotoServiceResponse<Void> response = flickrPhotoService.updatePhotoMetadata(new FlickrServiceRequest<>(request));
+
+        assertThat(response.isError()).isFalse();
+        verify(photosInterface).setMeta("photo-123", "Front view", "Photo description");
+        verify(photosInterface).setTags("photo-123", new String[]{"lego", "sealed"});
+    }
+
+    @Test
+    void updatePhotoMetadata_mapsProviderError() throws Exception {
+        HostedPhotoMetadataUpdate request = HostedPhotoMetadataUpdate.builder()
+                .photoId("photo-123")
+                .title("Front view")
+                .description("Photo description")
+                .build();
+        doThrow(new FlickrException("98", "metadata rejected"))
+                .when(photosInterface)
+                .setMeta("photo-123", "Front view", "Photo description");
+
+        PhotoServiceResponse<Void> response = flickrPhotoService.updatePhotoMetadata(new FlickrServiceRequest<>(request));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.responseCode()).isEqualTo(98);
+        assertThat(response.responseMessage()).isEqualTo("metadata rejected");
     }
 
     @Test

--- a/src/test/java/io/legohunter/imaging/metadata/MetadataFingerprintServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/metadata/MetadataFingerprintServiceTest.java
@@ -1,0 +1,51 @@
+package io.legohunter.imaging.metadata;
+
+import io.legohunter.imaging.metadata.model.ConditionEnum;
+import io.legohunter.imaging.metadata.model.ImageMetadata;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MetadataFingerprintServiceTest {
+    private final MetadataFingerprintService service = new MetadataFingerprintService();
+
+    @Test
+    void calculateHash_isStableForEquivalentNormalizedMetadata() {
+        String first = service.calculateHash(metadata(" ABC123 ", " 4558-1 ", "Front view"));
+        String second = service.calculateHash(metadata("abc123", "4558-1", "Front view"));
+
+        assertThat(first)
+                .hasSize(64)
+                .isEqualTo(second);
+    }
+
+    @Test
+    void calculateHash_changesWhenSupportedMetadataChanges() {
+        String first = service.calculateHash(metadata("abc123", "4558-1", "Front view"));
+        String second = service.calculateHash(metadata("abc123", "4558-1", "Rear view"));
+
+        assertThat(first).isNotEqualTo(second);
+    }
+
+    @Test
+    void calculateHash_requiresMetadata() {
+        assertThatThrownBy(() -> service.calculateHash(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("metadata is required");
+    }
+
+    private ImageMetadata metadata(String uuid, String externalItemNumber, String caption) {
+        return new ImageMetadata(
+                uuid,
+                externalItemNumber,
+                true,
+                false,
+                true,
+                ConditionEnum.M,
+                ConditionEnum.E,
+                ConditionEnum.G,
+                caption
+        );
+    }
+}


### PR DESCRIPTION
Adds canonical image metadata hashing and a provider-neutral hosted-photo metadata update API. Implements Flickr setMeta/setTags support and unit coverage for metadata hashing plus Flickr metadata updates.