### PR TITLE
Set Flickr auth per provider call

### DIFF
--- a/src/main/java/io/legohunter/imaging/flickr/config/FlickrConfiguration.java
+++ b/src/main/java/io/legohunter/imaging/flickr/config/FlickrConfiguration.java
@@ -2,7 +2,6 @@ package io.legohunter.imaging.flickr.config;
 
 import com.flickr4java.flickr.Flickr;
 import com.flickr4java.flickr.REST;
-import com.flickr4java.flickr.RequestContext;
 import com.flickr4java.flickr.Transport;
 import com.flickr4java.flickr.auth.Auth;
 import com.flickr4java.flickr.auth.Permission;
@@ -11,7 +10,6 @@ import com.flickr4java.flickr.photos.PhotosInterface;
 import com.flickr4java.flickr.photos.upload.UploadInterface;
 import com.flickr4java.flickr.photosets.PhotosetsInterface;
 import com.flickr4java.flickr.uploader.IUploader;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,10 +18,8 @@ import static io.legohunter.imaging.flickr.config.FlickrProperties.Secrets;
 @Configuration
 public class FlickrConfiguration {
     @Bean
-    public Secrets getFlickrSecrets(FlickrProperties flickrProperties, @Value("${flickr.application-name}") String name) {
-        return flickrProperties.getFlickr()
-                               .getApplication(name)
-                               .getSecrets();
+    public Secrets getFlickrSecrets(FlickrProperties flickrProperties) {
+        return flickrProperties.getSecrets();
     }
 
     @Bean
@@ -32,17 +28,19 @@ public class FlickrConfiguration {
     }
 
     @Bean
-    public Transport flickrTransport(FlickrProperties flickrProperties, Secrets flickerSecrets) {
-        Transport transport = new REST();
-        RequestContext requestContext = RequestContext.getRequestContext();
+    public Auth flickrAuth(Secrets flickrSecrets) {
         Auth auth = new Auth();
         auth.setPermission(Permission.DELETE);
-        auth.setToken(flickerSecrets.getToken());
-        auth.setTokenSecret(flickerSecrets.getTokenSecret());
-        requestContext.setAuth(auth);
-        Flickr.debugRequest = flickrProperties.getDebugRequest();
-        Flickr.debugStream = flickrProperties.getDebugStream();
-        return transport;
+        auth.setToken(flickrSecrets.getToken());
+        auth.setTokenSecret(flickrSecrets.getTokenSecret());
+        return auth;
+    }
+
+    @Bean
+    public Transport flickrTransport(FlickrProperties flickrProperties) {
+        Flickr.debugRequest = Boolean.TRUE.equals(flickrProperties.getDebugRequest());
+        Flickr.debugStream = Boolean.TRUE.equals(flickrProperties.getDebugStream());
+        return new REST();
     }
 
     @Bean

--- a/src/main/java/io/legohunter/imaging/flickr/config/FlickrProperties.java
+++ b/src/main/java/io/legohunter/imaging/flickr/config/FlickrProperties.java
@@ -1,10 +1,5 @@
 package io.legohunter.imaging.flickr.config;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import io.legohunter.imaging.exception.LegoImagingException;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -13,13 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
 @Setter
 @Getter
 @ToString
@@ -27,64 +15,15 @@ import java.util.Optional;
 @Configuration
 @ConfigurationProperties(prefix = "flickr")
 public class FlickrProperties {
-    private Path clientConfigDir;
-    private Path clientConfigFile;
     private String applicationName;
     private Boolean debugRequest;
     private Boolean debugStream;
     private String userId;
-    private Flickr flickr;
-
-    public void setClientConfigDir(Path clientConfigDir) {
-        this.clientConfigDir = clientConfigDir;
-        loadPropertiesFromJson();
-    }
-
-    public void setClientConfigFile(Path clientConfigFile) {
-        this.clientConfigFile = clientConfigFile;
-        loadPropertiesFromJson();
-    }
-
-    private void loadPropertiesFromJson() {
-        Optional<Path> optionalDir = Optional.ofNullable(getClientConfigDir());
-        Optional<Path> optionalFile = Optional.ofNullable(getClientConfigFile());
-        if ((optionalDir.isPresent()) && (optionalFile.isPresent())) {
-            Path jsonConfigFile = Path.of(clientConfigDir.toString(), clientConfigFile.toString());
-            if (Files.exists(jsonConfigFile)) {
-                ObjectMapper mapper = new ObjectMapper();
-                mapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
-                mapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
-                try {
-                    flickr = mapper.readValue(jsonConfigFile.toFile(), Flickr.class);
-                    userId = flickr.getUserId();
-                    log.info("Loaded secure configuration [{}] from path [{}]", clientConfigFile, clientConfigDir);
-                } catch (IOException e) {
-                    throw new LegoImagingException(e);
-                }
-            } else {
-                throw new LegoImagingException("[" + jsonConfigFile.toAbsolutePath() + "] does not exist");
-            }
-        }
-    }
-
-    public Flickr getFlickr() {
-        return Optional.ofNullable(flickr).orElseThrow(() -> new LegoImagingException("flickr properties have not been loaded"));
-    }
+    private Secrets secrets;
 
     @Data
-    @JsonRootName(value = "flickr")
     public static class Flickr {
         private String userId;
-        private List<Application> applications = new ArrayList<>();
-
-        public Application getApplication(String name) {
-            return applications.stream().filter(a -> a.getName().equals(name)).findFirst().orElseThrow(() -> new LegoImagingException("["+name+" was not found"));
-        }
-    }
-
-    @Data
-    public static class Application {
-        private String name;
         private Secrets secrets;
     }
 

--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -2,6 +2,8 @@ package io.legohunter.imaging.flickr.impl;
 
 import com.flickr4java.flickr.Flickr;
 import com.flickr4java.flickr.FlickrException;
+import com.flickr4java.flickr.RequestContext;
+import com.flickr4java.flickr.auth.Auth;
 import com.flickr4java.flickr.photos.Photo;
 import com.flickr4java.flickr.photos.PhotosInterface;
 import com.flickr4java.flickr.photosets.Photoset;
@@ -37,13 +39,15 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
     private final IUploader uploader;
     private final PhotosetsInterface photosetsInterface;
     private final PhotosInterface photosInterface;
+    private final Auth flickrAuth;
 
     @Override
     public PhotoServiceResponse<String> uploadPhoto(PhotoServiceRequest<PhotoMetaDataV1> request) {
         PhotoServiceResponse<String> response;
         PhotoMetaDataV1 photoMetaData = request.get();
         try {
-            String photoId = uploader.upload(Files.readAllBytes(photoMetaData.getAbsolutePath()), uploadMetaData(photoMetaData));
+            byte[] photoBytes = Files.readAllBytes(photoMetaData.getAbsolutePath());
+            String photoId = withFlickrAuth(() -> uploader.upload(photoBytes, uploadMetaData(photoMetaData)));
             response = new FlickrServiceResponse<>(photoId);
         } catch (FlickrException e) {
             response = flickrError(e);
@@ -59,7 +63,8 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         PhotoServiceResponse<String> response;
         PhotoMetaDataV1 photoMetaData = request.get();
         try {
-            String photoId = uploader.replace(Files.readAllBytes(photoMetaData.getAbsolutePath()), photoMetaData.getPhotoId(), SYNC_UPLOAD);
+            byte[] photoBytes = Files.readAllBytes(photoMetaData.getAbsolutePath());
+            String photoId = withFlickrAuth(() -> uploader.replace(photoBytes, photoMetaData.getPhotoId(), SYNC_UPLOAD));
             response = new FlickrServiceResponse<>(photoId);
         } catch (FlickrException e) {
             response = flickrError(e);
@@ -74,7 +79,10 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
     public PhotoServiceResponse<Void> deletePhoto(PhotoServiceRequest<String> request) {
         PhotoServiceResponse<Void> response;
         try {
-            photosInterface.delete(request.get());
+            withFlickrAuth(() -> {
+                photosInterface.delete(request.get());
+                return null;
+            });
             response = new FlickrServiceResponse<>((Void) null);
         } catch (FlickrException e) {
             response = flickrError(e);
@@ -92,7 +100,10 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
                 throw new LegoImagingException("Cannot create a Flickr Album that has no photos");
             }
             PhotoMetaDataV1 primaryPhoto = albumManifest.getPrimaryPhoto();
-            Photoset photoset = photosetsInterface.create(albumManifest.getTitle(), albumManifest.getDescription(), primaryPhoto.getPhotoId());
+            Photoset photoset = withFlickrAuth(() -> photosetsInterface.create(
+                    albumManifest.getTitle(),
+                    albumManifest.getDescription(),
+                    primaryPhoto.getPhotoId()));
             response = new FlickrServiceResponse<>(HostedAlbum.builder()
                     .id(photoset.getId())
                     .url(photoset.getUrl())
@@ -109,10 +120,13 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         PhotoServiceResponse<Void> response;
         HostedAlbumMembershipRequest membershipRequest = request.get();
         try {
-            photosetsInterface.editPhotos(
-                    membershipRequest.getAlbumId(),
-                    membershipRequest.getPrimaryPhotoId(),
-                    membershipRequest.getPhotoIds().toArray(String[]::new));
+            withFlickrAuth(() -> {
+                photosetsInterface.editPhotos(
+                        membershipRequest.getAlbumId(),
+                        membershipRequest.getPrimaryPhotoId(),
+                        membershipRequest.getPhotoIds().toArray(String[]::new));
+                return null;
+            });
             response = new FlickrServiceResponse<>((Void) null);
         } catch (FlickrException e) {
             response = flickrError(e);
@@ -126,13 +140,16 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         PhotoServiceResponse<Void> response;
         HostedPhotoMetadataUpdate metadataUpdate = request.get();
         try {
-            photosInterface.setMeta(
-                    metadataUpdate.getPhotoId(),
-                    metadataUpdate.getTitle(),
-                    metadataUpdate.getDescription());
-            if (metadataUpdate.getTags() != null && !metadataUpdate.getTags().isEmpty()) {
-                photosInterface.setTags(metadataUpdate.getPhotoId(), metadataUpdate.getTags().toArray(String[]::new));
-            }
+            withFlickrAuth(() -> {
+                photosInterface.setMeta(
+                        metadataUpdate.getPhotoId(),
+                        metadataUpdate.getTitle(),
+                        metadataUpdate.getDescription());
+                if (metadataUpdate.getTags() != null && !metadataUpdate.getTags().isEmpty()) {
+                    photosInterface.setTags(metadataUpdate.getPhotoId(), metadataUpdate.getTags().toArray(String[]::new));
+                }
+                return null;
+            });
             response = new FlickrServiceResponse<>((Void) null);
         } catch (FlickrException e) {
             response = flickrError(e);
@@ -146,7 +163,7 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         PhotoServiceResponse<HostedPhoto> response;
         String photoId = request.get();
         try {
-            Photo photo = photosInterface.getPhoto(photoId);
+            Photo photo = withFlickrAuth(() -> photosInterface.getPhoto(photoId));
             response = new FlickrServiceResponse<>(HostedPhoto.builder()
                     .id(photo.getId())
                     .title(photo.getTitle())
@@ -175,7 +192,23 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         return uploadMetaData;
     }
 
+    private <T> T withFlickrAuth(FlickrCall<T> call) throws FlickrException {
+        RequestContext requestContext = RequestContext.getRequestContext();
+        Auth previousAuth = requestContext.getAuth();
+        requestContext.setAuth(flickrAuth);
+        try {
+            return call.execute();
+        } finally {
+            requestContext.setAuth(previousAuth);
+        }
+    }
+
     private <T> PhotoServiceResponse<T> flickrError(FlickrException e) {
         return new FlickrServiceResponse<>(e, e.getErrorCode(), e.getErrorMessage());
+    }
+
+    @FunctionalInterface
+    private interface FlickrCall<T> {
+        T execute() throws FlickrException;
     }
 }

--- a/src/test/java/io/legohunter/imaging/flickr/config/FlickrConfigurationTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/config/FlickrConfigurationTest.java
@@ -1,0 +1,62 @@
+package io.legohunter.imaging.flickr.config;
+
+import com.flickr4java.flickr.Flickr;
+import com.flickr4java.flickr.RequestContext;
+import com.flickr4java.flickr.REST;
+import com.flickr4java.flickr.Transport;
+import com.flickr4java.flickr.auth.Auth;
+import com.flickr4java.flickr.auth.Permission;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlickrConfigurationTest {
+    private final FlickrConfiguration configuration = new FlickrConfiguration();
+
+    @AfterEach
+    void tearDown() {
+        RequestContext.getRequestContext().setAuth(null);
+        Flickr.debugRequest = false;
+        Flickr.debugStream = false;
+    }
+
+    @Test
+    void flickrAuth_buildsDeletePermissionAuthFromSecrets() {
+        FlickrProperties.Secrets secrets = new FlickrProperties.Secrets();
+        secrets.setToken("oauth-token");
+        secrets.setTokenSecret("oauth-token-secret");
+
+        Auth auth = configuration.flickrAuth(secrets);
+
+        assertThat(auth.getPermission()).isEqualTo(Permission.DELETE);
+        assertThat(auth.getToken()).isEqualTo("oauth-token");
+        assertThat(auth.getTokenSecret()).isEqualTo("oauth-token-secret");
+    }
+
+    @Test
+    void flickrTransport_doesNotBindAuthToTheBeanCreationThread() {
+        FlickrProperties properties = new FlickrProperties();
+        properties.setDebugRequest(true);
+        properties.setDebugStream(false);
+        Auth existingAuth = new Auth();
+        RequestContext.getRequestContext().setAuth(existingAuth);
+
+        Transport transport = configuration.flickrTransport(properties);
+
+        assertThat(transport).isInstanceOf(REST.class);
+        assertThat(Flickr.debugRequest).isTrue();
+        assertThat(Flickr.debugStream).isFalse();
+        assertThat(RequestContext.getRequestContext().getAuth()).isSameAs(existingAuth);
+    }
+
+    @Test
+    void flickrTransport_treatsMissingDebugFlagsAsDisabled() {
+        FlickrProperties properties = new FlickrProperties();
+
+        configuration.flickrTransport(properties);
+
+        assertThat(Flickr.debugRequest).isFalse();
+        assertThat(Flickr.debugStream).isFalse();
+    }
+}

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -2,6 +2,9 @@ package io.legohunter.imaging.flickr.impl;
 
 import com.flickr4java.flickr.Flickr;
 import com.flickr4java.flickr.FlickrException;
+import com.flickr4java.flickr.RequestContext;
+import com.flickr4java.flickr.auth.Auth;
+import com.flickr4java.flickr.auth.Permission;
 import com.flickr4java.flickr.photos.Photo;
 import com.flickr4java.flickr.photos.PhotosInterface;
 import com.flickr4java.flickr.photosets.Photoset;
@@ -16,6 +19,7 @@ import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,6 +32,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -38,6 +43,7 @@ class FlickrPhotoServiceTest {
     private IUploader uploader;
     private PhotosetsInterface photosetsInterface;
     private PhotosInterface photosInterface;
+    private Auth flickrAuth;
     private FlickrPhotoServiceImpl flickrPhotoService;
 
     @BeforeEach
@@ -45,7 +51,17 @@ class FlickrPhotoServiceTest {
         uploader = mock(IUploader.class);
         photosetsInterface = mock(PhotosetsInterface.class);
         photosInterface = mock(PhotosInterface.class);
-        flickrPhotoService = new FlickrPhotoServiceImpl(uploader, photosetsInterface, photosInterface);
+        flickrAuth = new Auth();
+        flickrAuth.setPermission(Permission.DELETE);
+        flickrAuth.setToken("oauth-token");
+        flickrAuth.setTokenSecret("oauth-token-secret");
+        RequestContext.getRequestContext().setAuth(null);
+        flickrPhotoService = new FlickrPhotoServiceImpl(uploader, photosetsInterface, photosInterface, flickrAuth);
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContext.getRequestContext().setAuth(null);
     }
 
     @Test
@@ -72,6 +88,40 @@ class FlickrPhotoServiceTest {
         assertThat(metadata.isHidden()).isFalse();
         assertThat(metadata.getSafetyLevel()).isEqualTo(Flickr.SAFETYLEVEL_SAFE);
         assertThat(metadata.getTags()).isEmpty();
+    }
+
+    @Test
+    void uploadPhoto_setsFlickrAuthOnCurrentThreadAndRestoresPreviousAuth(@TempDir Path tempDir) throws Exception {
+        Path photoPath = tempDir.resolve("photo.jpg");
+        Files.write(photoPath, new byte[]{1, 2, 3});
+        Auth previousAuth = new Auth();
+        previousAuth.setToken("previous-token");
+        RequestContext.getRequestContext().setAuth(previousAuth);
+        doAnswer(invocation -> {
+            assertThat(RequestContext.getRequestContext().getAuth()).isSameAs(flickrAuth);
+            return "photo-123";
+        }).when(uploader).upload(any(byte[].class), any(UploadMetaData.class));
+
+        PhotoServiceResponse<String> response = flickrPhotoService.uploadPhoto(new FlickrServiceRequest<>(new PhotoMetaDataV1(photoPath)));
+
+        assertThat(response.isError()).isFalse();
+        assertThat(RequestContext.getRequestContext().getAuth()).isSameAs(previousAuth);
+    }
+
+    @Test
+    void uploadPhoto_restoresPreviousAuthWhenProviderFails(@TempDir Path tempDir) throws Exception {
+        Path photoPath = tempDir.resolve("photo.jpg");
+        Files.write(photoPath, new byte[]{1});
+        Auth previousAuth = new Auth();
+        previousAuth.setToken("previous-token");
+        RequestContext.getRequestContext().setAuth(previousAuth);
+        when(uploader.upload(any(byte[].class), any(UploadMetaData.class)))
+                .thenThrow(new FlickrException("99", "Insufficient permissions"));
+
+        PhotoServiceResponse<String> response = flickrPhotoService.uploadPhoto(new FlickrServiceRequest<>(new PhotoMetaDataV1(photoPath)));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(RequestContext.getRequestContext().getAuth()).isSameAs(previousAuth);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Move Flickr OAuth token setup into a dedicated Auth bean
- Stop setting Flickr4Java RequestContext auth during REST transport bean creation because RequestContext is ThreadLocal
- Wrap Flickr provider calls so the configured Auth is applied to the current request thread and restored afterward
- Keep YAML-based Flickr credential binding and make debug flag handling null-safe

## Validation
- mvn test -Dtest=FlickrConfigurationTest,FlickrPhotoServiceTest
- mvn test