### PR TITLE
Add hosted album metadata update support

### DIFF
--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -16,6 +16,7 @@ import io.legohunter.imaging.flickr.model.FlickrServiceResponse;
 import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
+import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
@@ -125,6 +126,26 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
                         membershipRequest.getAlbumId(),
                         membershipRequest.getPrimaryPhotoId(),
                         membershipRequest.getPhotoIds().toArray(String[]::new));
+                return null;
+            });
+            response = new FlickrServiceResponse<>((Void) null);
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<Void> updateAlbumMetadata(PhotoServiceRequest<HostedAlbumMetadataUpdate> request) {
+        PhotoServiceResponse<Void> response;
+        HostedAlbumMetadataUpdate metadataUpdate = request.get();
+        try {
+            withFlickrAuth(() -> {
+                photosetsInterface.editMeta(
+                        metadataUpdate.getAlbumId(),
+                        metadataUpdate.getTitle(),
+                        metadataUpdate.getDescription());
                 return null;
             });
             response = new FlickrServiceResponse<>((Void) null);

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbumMetadataUpdate.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbumMetadataUpdate.java
@@ -1,0 +1,12 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class HostedAlbumMetadataUpdate {
+    private String albumId;
+    private String title;
+    private String description;
+}

--- a/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
+++ b/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
@@ -3,6 +3,7 @@ package io.legohunter.imaging.service.hosting.api;
 import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
+import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
@@ -19,6 +20,8 @@ public interface ImageHostingService {
     PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<AlbumManifest> request);
 
     PhotoServiceResponse<Void> updateAlbumMembership(PhotoServiceRequest<HostedAlbumMembershipRequest> request);
+
+    PhotoServiceResponse<Void> updateAlbumMetadata(PhotoServiceRequest<HostedAlbumMetadataUpdate> request);
 
     PhotoServiceResponse<Void> updatePhotoMetadata(PhotoServiceRequest<HostedPhotoMetadataUpdate> request);
 

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -15,6 +15,7 @@ import io.legohunter.imaging.flickr.model.FlickrServiceRequest;
 import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
+import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
@@ -179,6 +180,38 @@ class FlickrPhotoServiceTest {
 
         assertThat(response.isError()).isFalse();
         verify(photosetsInterface).editPhotos("album-123", "photo-1", new String[]{"photo-1", "photo-2"});
+    }
+
+    @Test
+    void updateAlbumMetadata_editsPhotosetMetadata() throws Exception {
+        HostedAlbumMetadataUpdate request = HostedAlbumMetadataUpdate.builder()
+                .albumId("album-123")
+                .title("4558-1 - Metroliner")
+                .description("Inventory item [inventory-uuid]")
+                .build();
+
+        PhotoServiceResponse<Void> response = flickrPhotoService.updateAlbumMetadata(new FlickrServiceRequest<>(request));
+
+        assertThat(response.isError()).isFalse();
+        verify(photosetsInterface).editMeta("album-123", "4558-1 - Metroliner", "Inventory item [inventory-uuid]");
+    }
+
+    @Test
+    void updateAlbumMetadata_mapsProviderError() throws Exception {
+        HostedAlbumMetadataUpdate request = HostedAlbumMetadataUpdate.builder()
+                .albumId("album-123")
+                .title("4558-1 - Metroliner")
+                .description("Inventory item [inventory-uuid]")
+                .build();
+        doThrow(new FlickrException("97", "album metadata rejected"))
+                .when(photosetsInterface)
+                .editMeta("album-123", "4558-1 - Metroliner", "Inventory item [inventory-uuid]");
+
+        PhotoServiceResponse<Void> response = flickrPhotoService.updateAlbumMetadata(new FlickrServiceRequest<>(request));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.responseCode()).isEqualTo(97);
+        assertThat(response.responseMessage()).isEqualTo("album metadata rejected");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add provider-agnostic HostedAlbumMetadataUpdate request model
- add ImageHostingService.updateAlbumMetadata contract
- implement Flickr photoset metadata updates through flickr4java
- add tests for successful Flickr metadata updates and provider error handling

## Testing
- mvn -Dtest=FlickrPhotoServiceTest test
- mvn install -DskipTests
- mvn clean install