### PR TITLE
Classify missing hosted albums

### DIFF
--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -20,6 +20,7 @@ import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
+import io.legohunter.imaging.model.PhotoServiceErrorType;
 import io.legohunter.imaging.model.PhotoServiceRequest;
 import io.legohunter.imaging.model.PhotoServiceResponse;
 import lombok.RequiredArgsConstructor;
@@ -225,7 +226,15 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
     }
 
     private <T> PhotoServiceResponse<T> flickrError(FlickrException e) {
-        return new FlickrServiceResponse<>(e, e.getErrorCode(), e.getErrorMessage());
+        return new FlickrServiceResponse<>(e, e.getErrorCode(), e.getErrorMessage(), flickrErrorType(e));
+    }
+
+    private PhotoServiceErrorType flickrErrorType(FlickrException e) {
+        String message = e.getErrorMessage();
+        if (message != null && message.equalsIgnoreCase("Photoset not found")) {
+            return PhotoServiceErrorType.ALBUM_NOT_FOUND;
+        }
+        return PhotoServiceErrorType.UNKNOWN;
     }
 
     @FunctionalInterface

--- a/src/main/java/io/legohunter/imaging/flickr/model/FlickrServiceResponse.java
+++ b/src/main/java/io/legohunter/imaging/flickr/model/FlickrServiceResponse.java
@@ -1,6 +1,7 @@
 package io.legohunter.imaging.flickr.model;
 
 import io.legohunter.imaging.model.PhotoServiceResponse;
+import io.legohunter.imaging.model.PhotoServiceErrorType;
 
 import java.util.Optional;
 
@@ -11,6 +12,7 @@ public class FlickrServiceResponse<T> implements PhotoServiceResponse<T> {
     private Exception e;
     private String errorCode;
     private String errorMessage;
+    private PhotoServiceErrorType errorType;
 
 
 
@@ -19,9 +21,14 @@ public class FlickrServiceResponse<T> implements PhotoServiceResponse<T> {
     }
 
     public FlickrServiceResponse(Exception e, String errorCode, String errorMessage) {
+        this(e, errorCode, errorMessage, PhotoServiceErrorType.UNKNOWN);
+    }
+
+    public FlickrServiceResponse(Exception e, String errorCode, String errorMessage, PhotoServiceErrorType errorType) {
         this.e = e;
         this.errorCode = errorCode;
         this.errorMessage = errorMessage;
+        this.errorType = errorType;
     }
 
     public FlickrServiceResponse(Exception e) {
@@ -45,6 +52,11 @@ public class FlickrServiceResponse<T> implements PhotoServiceResponse<T> {
     @Override
     public String responseMessage() {
         return errorMessage;
+    }
+
+    @Override
+    public PhotoServiceErrorType errorType() {
+        return Optional.ofNullable(errorType).orElse(PhotoServiceErrorType.UNKNOWN);
     }
 
     public Exception getE() {

--- a/src/main/java/io/legohunter/imaging/model/PhotoServiceErrorType.java
+++ b/src/main/java/io/legohunter/imaging/model/PhotoServiceErrorType.java
@@ -1,0 +1,6 @@
+package io.legohunter.imaging.model;
+
+public enum PhotoServiceErrorType {
+    ALBUM_NOT_FOUND,
+    UNKNOWN
+}

--- a/src/main/java/io/legohunter/imaging/model/PhotoServiceResponse.java
+++ b/src/main/java/io/legohunter/imaging/model/PhotoServiceResponse.java
@@ -7,4 +7,8 @@ public interface PhotoServiceResponse<T> extends Supplier<T>, Consumer<T> {
     boolean isError();
     Integer responseCode();
     String responseMessage();
+
+    default PhotoServiceErrorType errorType() {
+        return PhotoServiceErrorType.UNKNOWN;
+    }
 }

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -19,6 +19,7 @@ import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
+import io.legohunter.imaging.model.PhotoServiceErrorType;
 import io.legohunter.imaging.model.PhotoServiceResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -180,6 +181,24 @@ class FlickrPhotoServiceTest {
 
         assertThat(response.isError()).isFalse();
         verify(photosetsInterface).editPhotos("album-123", "photo-1", new String[]{"photo-1", "photo-2"});
+    }
+
+    @Test
+    void updateAlbumMembership_mapsMissingPhotosetToAlbumNotFoundErrorType() throws Exception {
+        HostedAlbumMembershipRequest request = HostedAlbumMembershipRequest.builder()
+                .albumId("missing-album")
+                .primaryPhotoId("photo-1")
+                .photoIds(new LinkedHashSet<>(List.of("photo-1", "photo-2")))
+                .build();
+        doThrow(new FlickrException("1", "Photoset not found"))
+                .when(photosetsInterface)
+                .editPhotos("missing-album", "photo-1", new String[]{"photo-1", "photo-2"});
+
+        PhotoServiceResponse<Void> response = flickrPhotoService.updateAlbumMembership(new FlickrServiceRequest<>(request));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.errorType()).isEqualTo(PhotoServiceErrorType.ALBUM_NOT_FOUND);
+        assertThat(response.responseMessage()).isEqualTo("Photoset not found");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add provider-neutral PhotoServiceErrorType to PhotoServiceResponse
- map Flickr 'Photoset not found' errors to ALBUM_NOT_FOUND
- keep existing provider response code/message available for logging and diagnostics
- add Flickr service test coverage for missing photoset classification

## Testing
- mvn -Dtest=FlickrPhotoServiceTest test
- mvn clean install