### PR TITLE
Add Flickr album and photo listing support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,13 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar -Xshare:off</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/io/legohunter/imaging/bitly/api/BitlinksAPI.java
+++ b/src/main/java/io/legohunter/imaging/bitly/api/BitlinksAPI.java
@@ -2,11 +2,19 @@ package io.legohunter.imaging.bitly.api;
 
 import io.legohunter.imaging.bitly.model.bitly.ShortenRequest;
 import io.legohunter.imaging.bitly.model.bitly.Bitlink;
+import io.legohunter.imaging.bitly.model.bitly.BitlinksPage;
 import feign.Headers;
+import feign.Param;
+import feign.QueryMap;
 import feign.RequestLine;
+
+import java.util.Map;
 
 public interface BitlinksAPI {
     @RequestLine("POST /shorten")
     @Headers("Content-Type: application/json")
     public Bitlink shorten(ShortenRequest request);
+
+    @RequestLine("GET /groups/{groupGuid}/bitlinks")
+    public BitlinksPage listBitlinks(@Param("groupGuid") String groupGuid, @QueryMap Map<String, Object> query);
 }

--- a/src/main/java/io/legohunter/imaging/bitly/config/BitlyConfiguration.java
+++ b/src/main/java/io/legohunter/imaging/bitly/config/BitlyConfiguration.java
@@ -6,10 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.legohunter.imaging.bitly.exception.BitlyException;
-import io.legohunter.imaging.bitly.api.BitlinksAPI;
-import io.legohunter.imaging.bitly.model.bitly.BitlyError;
-import io.legohunter.imaging.bitly.impl.BitlinksService;
 import feign.Feign;
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
@@ -19,6 +15,10 @@ import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
+import io.legohunter.imaging.bitly.api.BitlinksAPI;
+import io.legohunter.imaging.bitly.exception.BitlyException;
+import io.legohunter.imaging.bitly.impl.BitlinksService;
+import io.legohunter.imaging.bitly.model.bitly.BitlyError;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -52,7 +52,7 @@ public class BitlyConfiguration {
     @Bean
     public BitlinksAPI bitlinksAPI(@Qualifier("bitlyObjectMapper") ObjectMapper bitlyObjectMapper, BitlyProperties bitlyProperties) {
         return builder(bitlyObjectMapper, bitlyProperties)
-                .target(BitlinksAPI.class, bitlyProperties.getBitly().getBaseUrl());
+                .target(BitlinksAPI.class, bitlyProperties.getBaseUrl());
     }
 
     private Feign.Builder builder(@Qualifier("bitlyObjectMapper") ObjectMapper bitlyObjectMapper, BitlyProperties bitlyProperties) {
@@ -63,7 +63,7 @@ public class BitlyConfiguration {
                     .encoder(new JacksonEncoder(bitlyObjectMapper))
                     .decoder(new JacksonDecoder(bitlyObjectMapper))
                     .errorDecoder(new BitlyErrorDecoder(bitlyObjectMapper))
-                    .requestInterceptor(new OAuthRequestInterceptor(bitlyProperties.getBitly().getAccessToken()))
+                    .requestInterceptor(new OAuthRequestInterceptor(bitlyProperties.getAccessToken()))
                     .logger(new Slf4jLogger(BitlinksAPI.class))
                     .logLevel(feign.Logger.Level.FULL);
 

--- a/src/main/java/io/legohunter/imaging/bitly/config/BitlyProperties.java
+++ b/src/main/java/io/legohunter/imaging/bitly/config/BitlyProperties.java
@@ -1,11 +1,5 @@
 package io.legohunter.imaging.bitly.config;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonRootName;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import io.legohunter.imaging.exception.LegoImagingException;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,11 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
-
 @Setter
 @Getter
 @ToString
@@ -26,57 +15,14 @@ import java.util.Optional;
 @Configuration
 @ConfigurationProperties(prefix = "bitly")
 public class BitlyProperties {
-    private Path clientConfigDir;
-    private Path clientConfigFile;
-    private Bitly bitly = new Bitly();
-
-    public void setClientConfigDir(Path clientConfigDir) {
-        this.clientConfigDir = clientConfigDir;
-        loadPropertiesFromJson();
-    }
-
-    public void setClientConfigFile(Path clientConfigFile) {
-        this.clientConfigFile = clientConfigFile;
-        loadPropertiesFromJson();
-    }
-
-    private void loadPropertiesFromJson() {
-        Optional<Path> optionalDir = Optional.ofNullable(getClientConfigDir());
-        Optional<Path> optionalFile = Optional.ofNullable(getClientConfigFile());
-        if ((optionalDir.isPresent()) && (optionalFile.isPresent())) {
-            Path jsonConfigFile = Path.of(clientConfigDir.toString(), clientConfigFile.toString());
-            if (Files.exists(jsonConfigFile)) {
-                ObjectMapper mapper = new ObjectMapper();
-                mapper.enable(SerializationFeature.WRAP_ROOT_VALUE);
-                mapper.configure(DeserializationFeature.UNWRAP_ROOT_VALUE, true);
-                try {
-                    bitly = mapper.readValue(jsonConfigFile.toFile(), Bitly.class);
-                    log.info("Loaded secure configuration [{}] from path [{}]", clientConfigFile, clientConfigDir);
-                } catch (IOException e) {
-                    throw new LegoImagingException(e);
-                }
-            } else {
-                throw new LegoImagingException("[" + jsonConfigFile.toAbsolutePath() + "] does not exist");
-            }
-        }
-    }
-
-    @Data
-    @JsonRootName(value = "bitly")
-    public static class Bitly {
-        private String accessToken;
-        private String groupGuid;
-        @JsonProperty(value = "oauth2")
-        private OAuth2 oAuth2;
-        private String baseUrl = "https://api-ssl.bitly.com/v4";
-    }
+    private String baseUrl = "https://api-ssl.bitly.com/v4";
+    private String accessToken;
+    private String groupGuid;
+    private OAuth2 oAuth2;
 
     @Data
     public static class OAuth2 {
-        @JsonProperty("client-id")
         private String clientId;
-
-        @JsonProperty("client-secret")
         private String clientSecret;
     }
 }

--- a/src/main/java/io/legohunter/imaging/bitly/config/BitlyProperties.java
+++ b/src/main/java/io/legohunter/imaging/bitly/config/BitlyProperties.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 public class BitlyProperties {
     private Path clientConfigDir;
     private Path clientConfigFile;
-    private Bitly bitly;
+    private Bitly bitly = new Bitly();
 
     public void setClientConfigDir(Path clientConfigDir) {
         this.clientConfigDir = clientConfigDir;
@@ -65,9 +65,10 @@ public class BitlyProperties {
     @JsonRootName(value = "bitly")
     public static class Bitly {
         private String accessToken;
+        private String groupGuid;
         @JsonProperty(value = "oauth2")
         private OAuth2 oAuth2;
-        private String baseUrl;
+        private String baseUrl = "https://api-ssl.bitly.com/v4";
     }
 
     @Data

--- a/src/main/java/io/legohunter/imaging/bitly/impl/BitlinksService.java
+++ b/src/main/java/io/legohunter/imaging/bitly/impl/BitlinksService.java
@@ -2,9 +2,13 @@ package io.legohunter.imaging.bitly.impl;
 
 import io.legohunter.imaging.bitly.api.BitlinksAPI;
 import io.legohunter.imaging.bitly.model.bitly.Bitlink;
+import io.legohunter.imaging.bitly.model.bitly.BitlinksPage;
 import io.legohunter.imaging.bitly.model.bitly.ShortenRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -13,5 +17,19 @@ public class BitlinksService {
 
     public Bitlink shorten(ShortenRequest request) {
         return bitlinksAPI.shorten(request);
+    }
+
+    public BitlinksPage listBitlinks(String groupGuid, int size, String searchAfter, String archived) {
+        Map<String, Object> query = new LinkedHashMap<>();
+        if (size > 0) {
+            query.put("size", size);
+        }
+        if (searchAfter != null && !searchAfter.isBlank()) {
+            query.put("search_after", searchAfter);
+        }
+        if (archived != null && !archived.isBlank()) {
+            query.put("archived", archived);
+        }
+        return bitlinksAPI.listBitlinks(groupGuid, query);
     }
 }

--- a/src/main/java/io/legohunter/imaging/bitly/model/bitly/BitlinksPage.java
+++ b/src/main/java/io/legohunter/imaging/bitly/model/bitly/BitlinksPage.java
@@ -1,0 +1,11 @@
+package io.legohunter.imaging.bitly.model.bitly;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BitlinksPage {
+    private List<Bitlink> links;
+    private Pagination pagination;
+}

--- a/src/main/java/io/legohunter/imaging/bitly/model/bitly/Pagination.java
+++ b/src/main/java/io/legohunter/imaging/bitly/model/bitly/Pagination.java
@@ -1,0 +1,14 @@
+package io.legohunter.imaging.bitly.model.bitly;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class Pagination {
+    private String next;
+
+    @JsonProperty("search_after")
+    private String searchAfter;
+
+    private Integer size;
+}

--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -4,8 +4,11 @@ import com.flickr4java.flickr.Flickr;
 import com.flickr4java.flickr.FlickrException;
 import com.flickr4java.flickr.RequestContext;
 import com.flickr4java.flickr.auth.Auth;
+import com.flickr4java.flickr.photos.Extras;
 import com.flickr4java.flickr.photos.Photo;
+import com.flickr4java.flickr.photos.PhotoList;
 import com.flickr4java.flickr.photos.PhotosInterface;
+import com.flickr4java.flickr.photosets.Photosets;
 import com.flickr4java.flickr.photosets.Photoset;
 import com.flickr4java.flickr.photosets.PhotosetsInterface;
 import com.flickr4java.flickr.uploader.IUploader;
@@ -15,10 +18,14 @@ import io.legohunter.imaging.flickr.api.FlickrPhotoService;
 import io.legohunter.imaging.flickr.model.FlickrServiceResponse;
 import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumPage;
+import io.legohunter.imaging.model.HostedAlbumPhotoSearchRequest;
+import io.legohunter.imaging.model.HostedAlbumSearchRequest;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
+import io.legohunter.imaging.model.HostedPhotoPage;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceErrorType;
 import io.legohunter.imaging.model.PhotoServiceRequest;
@@ -30,6 +37,9 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
@@ -109,6 +119,63 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
             response = new FlickrServiceResponse<>(HostedAlbum.builder()
                     .id(photoset.getId())
                     .url(photoset.getUrl())
+                    .build());
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<HostedAlbumPage> listAlbums(PhotoServiceRequest<HostedAlbumSearchRequest> request) {
+        PhotoServiceResponse<HostedAlbumPage> response;
+        HostedAlbumSearchRequest searchRequest = request.get();
+        try {
+            Photosets photosets = withFlickrAuth(() -> photosetsInterface.getList(
+                    searchRequest.getUserId(),
+                    positiveOrZero(searchRequest.getPerPage()),
+                    positiveOrZero(searchRequest.getPage()),
+                    null
+            ));
+            response = new FlickrServiceResponse<>(HostedAlbumPage.builder()
+                    .albums(Optional.ofNullable(photosets.getPhotosets()).orElse(Collections.emptyList()).stream()
+                            .map(this::toHostedAlbum)
+                            .toList())
+                    .page(photosets.getPage())
+                    .pages(photosets.getPages())
+                    .perPage(photosets.getPerPage())
+                    .total(photosets.getTotal())
+                    .build());
+        } catch (FlickrException e) {
+            response = flickrError(e);
+        }
+        log.debug("Flickr Response [{}]", response);
+        return response;
+    }
+
+    @Override
+    public PhotoServiceResponse<HostedPhotoPage> listAlbumPhotos(PhotoServiceRequest<HostedAlbumPhotoSearchRequest> request) {
+        PhotoServiceResponse<HostedPhotoPage> response;
+        HostedAlbumPhotoSearchRequest searchRequest = request.get();
+        try {
+            PhotoList<Photo> photos = withFlickrAuth(() -> photosetsInterface.getPhotos(
+                    searchRequest.getAlbumId(),
+                    Set.of(Extras.DATE_UPLOAD, Extras.URL_M, Extras.URL_O),
+                    Flickr.PRIVACY_LEVEL_NO_FILTER,
+                    positiveOrZero(searchRequest.getPerPage()),
+                    positiveOrZero(searchRequest.getPage())
+            ));
+            response = new FlickrServiceResponse<>(HostedPhotoPage.builder()
+                    .photos(Optional.ofNullable(photos)
+                            .map(PhotoList::stream)
+                            .orElseGet(Stream::empty)
+                            .map(this::toHostedPhoto)
+                            .toList())
+                    .page(photos.getPage())
+                    .pages(photos.getPages())
+                    .perPage(photos.getPerPage())
+                    .total(photos.getTotal())
                     .build());
         } catch (FlickrException e) {
             response = flickrError(e);
@@ -212,6 +279,34 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         uploadMetaData.setTags(Collections.emptyList());
         uploadMetaData.setTitle("Title [" + photoMetaData.getFilename() + "]");
         return uploadMetaData;
+    }
+
+    private HostedAlbum toHostedAlbum(Photoset photoset) {
+        return HostedAlbum.builder()
+                .id(photoset.getId())
+                .url(photoset.getUrl())
+                .title(photoset.getTitle())
+                .description(photoset.getDescription())
+                .primaryPhotoId(photoset.getPrimaryPhoto() == null ? null : photoset.getPrimaryPhoto().getId())
+                .photoCount(photoset.getPhotoCount())
+                .build();
+    }
+
+    private HostedPhoto toHostedPhoto(Photo photo) {
+        return HostedPhoto.builder()
+                .id(photo.getId())
+                .title(photo.getTitle())
+                .description(photo.getDescription())
+                .url(photo.getUrl())
+                .primary(photo.isPrimary())
+                .build();
+    }
+
+    private int positiveOrZero(Integer value) {
+        if (value == null || value < 1) {
+            return 0;
+        }
+        return value;
     }
 
     private <T> T withFlickrAuth(FlickrCall<T> call) throws FlickrException {

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbum.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbum.java
@@ -8,4 +8,8 @@ import lombok.Data;
 public class HostedAlbum {
     private String id;
     private String url;
+    private String title;
+    private String description;
+    private String primaryPhotoId;
+    private Integer photoCount;
 }

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbumPage.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbumPage.java
@@ -1,0 +1,18 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import java.util.List;
+
+@Data
+@Builder
+public class HostedAlbumPage {
+    @Singular
+    private List<HostedAlbum> albums;
+    private Integer page;
+    private Integer pages;
+    private Integer perPage;
+    private Integer total;
+}

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbumPhotoSearchRequest.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbumPhotoSearchRequest.java
@@ -1,0 +1,12 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class HostedAlbumPhotoSearchRequest {
+    private String albumId;
+    private Integer page;
+    private Integer perPage;
+}

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbumSearchRequest.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbumSearchRequest.java
@@ -1,0 +1,12 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class HostedAlbumSearchRequest {
+    private String userId;
+    private Integer page;
+    private Integer perPage;
+}

--- a/src/main/java/io/legohunter/imaging/model/HostedPhoto.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedPhoto.java
@@ -8,4 +8,7 @@ import lombok.Data;
 public class HostedPhoto {
     private String id;
     private String title;
+    private String description;
+    private String url;
+    private Boolean primary;
 }

--- a/src/main/java/io/legohunter/imaging/model/HostedPhotoPage.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedPhotoPage.java
@@ -1,0 +1,18 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import java.util.List;
+
+@Data
+@Builder
+public class HostedPhotoPage {
+    @Singular
+    private List<HostedPhoto> photos;
+    private Integer page;
+    private Integer pages;
+    private Integer perPage;
+    private Integer total;
+}

--- a/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
+++ b/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
@@ -2,10 +2,14 @@ package io.legohunter.imaging.service.hosting.api;
 
 import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumPage;
+import io.legohunter.imaging.model.HostedAlbumPhotoSearchRequest;
+import io.legohunter.imaging.model.HostedAlbumSearchRequest;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
+import io.legohunter.imaging.model.HostedPhotoPage;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceRequest;
 import io.legohunter.imaging.model.PhotoServiceResponse;
@@ -18,6 +22,10 @@ public interface ImageHostingService {
     PhotoServiceResponse<Void> deletePhoto(PhotoServiceRequest<String> request);
 
     PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<AlbumManifest> request);
+
+    PhotoServiceResponse<HostedAlbumPage> listAlbums(PhotoServiceRequest<HostedAlbumSearchRequest> request);
+
+    PhotoServiceResponse<HostedPhotoPage> listAlbumPhotos(PhotoServiceRequest<HostedAlbumPhotoSearchRequest> request);
 
     PhotoServiceResponse<Void> updateAlbumMembership(PhotoServiceRequest<HostedAlbumMembershipRequest> request);
 

--- a/src/test/java/io/legohunter/imaging/bitly/impl/BitlinksServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/bitly/impl/BitlinksServiceTest.java
@@ -1,0 +1,67 @@
+package io.legohunter.imaging.bitly.impl;
+
+import io.legohunter.imaging.bitly.api.BitlinksAPI;
+import io.legohunter.imaging.bitly.model.bitly.Bitlink;
+import io.legohunter.imaging.bitly.model.bitly.BitlinksPage;
+import io.legohunter.imaging.bitly.model.bitly.ShortenRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BitlinksServiceTest {
+    @Mock
+    private BitlinksAPI bitlinksAPI;
+
+    @Test
+    void shortenDelegatesToBitlinksApi() {
+        BitlinksService service = new BitlinksService(bitlinksAPI);
+        ShortenRequest request = new ShortenRequest();
+        Bitlink bitlink = new Bitlink();
+        when(bitlinksAPI.shorten(request)).thenReturn(bitlink);
+
+        Bitlink response = service.shorten(request);
+
+        assertThat(response).isSameAs(bitlink);
+        verify(bitlinksAPI).shorten(request);
+    }
+
+    @Test
+    void listBitlinksBuildsQueryFromProvidedValues() {
+        BitlinksService service = new BitlinksService(bitlinksAPI);
+        BitlinksPage page = new BitlinksPage();
+        when(bitlinksAPI.listBitlinks(org.mockito.ArgumentMatchers.eq("group-1"), org.mockito.ArgumentMatchers.anyMap()))
+                .thenReturn(page);
+
+        BitlinksPage response = service.listBitlinks("group-1", 100, "cursor-1", "both");
+
+        assertThat(response).isSameAs(page);
+        ArgumentCaptor<Map<String, Object>> queryCaptor = ArgumentCaptor.captor();
+        verify(bitlinksAPI).listBitlinks(org.mockito.ArgumentMatchers.eq("group-1"), queryCaptor.capture());
+        assertThat(queryCaptor.getValue())
+                .containsEntry("size", 100)
+                .containsEntry("search_after", "cursor-1")
+                .containsEntry("archived", "both");
+    }
+
+    @Test
+    void listBitlinksOmitsBlankOptionalValues() {
+        BitlinksService service = new BitlinksService(bitlinksAPI);
+        when(bitlinksAPI.listBitlinks(org.mockito.ArgumentMatchers.eq("group-1"), org.mockito.ArgumentMatchers.anyMap()))
+                .thenReturn(new BitlinksPage());
+
+        service.listBitlinks("group-1", 0, " ", null);
+
+        ArgumentCaptor<Map<String, Object>> queryCaptor = ArgumentCaptor.captor();
+        verify(bitlinksAPI).listBitlinks(org.mockito.ArgumentMatchers.eq("group-1"), queryCaptor.capture());
+        assertThat(queryCaptor.getValue()).isEmpty();
+    }
+}

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -6,7 +6,9 @@ import com.flickr4java.flickr.RequestContext;
 import com.flickr4java.flickr.auth.Auth;
 import com.flickr4java.flickr.auth.Permission;
 import com.flickr4java.flickr.photos.Photo;
+import com.flickr4java.flickr.photos.PhotoList;
 import com.flickr4java.flickr.photos.PhotosInterface;
+import com.flickr4java.flickr.photosets.Photosets;
 import com.flickr4java.flickr.photosets.Photoset;
 import com.flickr4java.flickr.photosets.PhotosetsInterface;
 import com.flickr4java.flickr.uploader.IUploader;
@@ -14,10 +16,14 @@ import com.flickr4java.flickr.uploader.UploadMetaData;
 import io.legohunter.imaging.flickr.model.FlickrServiceRequest;
 import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumPage;
+import io.legohunter.imaging.model.HostedAlbumPhotoSearchRequest;
+import io.legohunter.imaging.model.HostedAlbumSearchRequest;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
+import io.legohunter.imaging.model.HostedPhotoPage;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceErrorType;
 import io.legohunter.imaging.model.PhotoServiceResponse;
@@ -167,6 +173,114 @@ class FlickrPhotoServiceTest {
         assertThat(response.get().getId()).isEqualTo("album-123");
         assertThat(response.get().getUrl()).isEqualTo("https://www.flickr.com/photos/user/albums/album-123");
         verify(photosetsInterface).create("album title", "album description", "primary-photo");
+    }
+
+    @Test
+    void listAlbums_mapsFlickrPhotosets() throws Exception {
+        Photoset photoset = new Photoset();
+        photoset.setId("album-123");
+        photoset.setUrl("https://www.flickr.com/photos/user/sets/album-123/");
+        photoset.setTitle("4558-1 - Metroliner");
+        photoset.setDescription("inventory-uuid");
+        photoset.setPhotoCount(2);
+        Photo primaryPhoto = new Photo();
+        primaryPhoto.setId("photo-1");
+        photoset.setPrimaryPhoto(primaryPhoto);
+        Photosets photosets = new Photosets();
+        photosets.setPhotosets(List.of(photoset));
+        photosets.setPage(1);
+        photosets.setPages(3);
+        photosets.setPerPage(1);
+        photosets.setTotal(3);
+        when(photosetsInterface.getList("user-123", 1, 1, null)).thenReturn(photosets);
+
+        PhotoServiceResponse<HostedAlbumPage> response = flickrPhotoService.listAlbums(new FlickrServiceRequest<>(
+                HostedAlbumSearchRequest.builder()
+                        .userId("user-123")
+                        .page(1)
+                        .perPage(1)
+                        .build()
+        ));
+
+        assertThat(response.isError()).isFalse();
+        assertThat(response.get().getPage()).isEqualTo(1);
+        assertThat(response.get().getPages()).isEqualTo(3);
+        assertThat(response.get().getPerPage()).isEqualTo(1);
+        assertThat(response.get().getTotal()).isEqualTo(3);
+        assertThat(response.get().getAlbums()).singleElement()
+                .extracting(
+                        HostedAlbum::getId,
+                        HostedAlbum::getUrl,
+                        HostedAlbum::getTitle,
+                        HostedAlbum::getDescription,
+                        HostedAlbum::getPrimaryPhotoId,
+                        HostedAlbum::getPhotoCount
+                )
+                .containsExactly(
+                        "album-123",
+                        "https://www.flickr.com/photos/user/sets/album-123/",
+                        "4558-1 - Metroliner",
+                        "inventory-uuid",
+                        "photo-1",
+                        2
+                );
+    }
+
+    @Test
+    void listAlbumPhotos_mapsFlickrPhotos() throws Exception {
+        Photo photo = new Photo();
+        photo.setId("photo-1");
+        photo.setTitle("front.jpg");
+        photo.setDescription("Front view");
+        photo.setUrl("https://flickr.com/photos/user/photo-1");
+        photo.setPrimary(true);
+        PhotoList<Photo> photos = new PhotoList<>();
+        photos.add(photo);
+        photos.setPage(1);
+        photos.setPages(1);
+        photos.setPerPage(500);
+        photos.setTotal(1);
+        when(photosetsInterface.getPhotos(eq("album-123"), any(), eq(Flickr.PRIVACY_LEVEL_NO_FILTER), eq(500), eq(1)))
+                .thenReturn(photos);
+
+        PhotoServiceResponse<HostedPhotoPage> response = flickrPhotoService.listAlbumPhotos(new FlickrServiceRequest<>(
+                HostedAlbumPhotoSearchRequest.builder()
+                        .albumId("album-123")
+                        .page(1)
+                        .perPage(500)
+                        .build()
+        ));
+
+        assertThat(response.isError()).isFalse();
+        assertThat(response.get().getPage()).isEqualTo(1);
+        assertThat(response.get().getPages()).isEqualTo(1);
+        assertThat(response.get().getPerPage()).isEqualTo(500);
+        assertThat(response.get().getTotal()).isEqualTo(1);
+        assertThat(response.get().getPhotos()).singleElement()
+                .extracting(
+                        HostedPhoto::getId,
+                        HostedPhoto::getTitle,
+                        HostedPhoto::getDescription,
+                        HostedPhoto::getUrl,
+                        HostedPhoto::getPrimary
+                )
+                .containsExactly("photo-1", "front.jpg", "Front view", "https://flickr.com/photos/user/photo-1", true);
+    }
+
+    @Test
+    void listAlbums_mapsProviderError() throws Exception {
+        when(photosetsInterface.getList("user-123", 0, 0, null))
+                .thenThrow(new FlickrException("99", "provider rejected album list"));
+
+        PhotoServiceResponse<HostedAlbumPage> response = flickrPhotoService.listAlbums(new FlickrServiceRequest<>(
+                HostedAlbumSearchRequest.builder()
+                        .userId("user-123")
+                        .build()
+        ));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.responseCode()).isEqualTo(99);
+        assertThat(response.responseMessage()).isEqualTo("provider rejected album list");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add provider-agnostic paged hosted album/photo listing models.
- Extend ImageHostingService with album and album-photo read operations.
- Implement Flickr album/photo listing and map Flickr responses to hosted DTOs.
- Add tests for successful listing and Flickr error mapping.

## Verification
- mvn clean install