### PR TITLE
Flickr Phase 3 PR9: Harden Flickr error classification

### DIFF
--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -64,7 +64,7 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         } catch (FlickrException e) {
             response = flickrError(e);
         } catch (IOException e) {
-            response = new FlickrServiceResponse<>(e);
+            response = new FlickrServiceResponse<>(e, FlickrServiceResponse.INTERNAL_ERROR_CODE, e.getMessage(), PhotoServiceErrorType.VALIDATION_FAILED);
         }
         log.debug("Flickr Response [{}]", response);
         return response;
@@ -81,7 +81,7 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
         } catch (FlickrException e) {
             response = flickrError(e);
         } catch (IOException e) {
-            response = new FlickrServiceResponse<>(e);
+            response = new FlickrServiceResponse<>(e, FlickrServiceResponse.INTERNAL_ERROR_CODE, e.getMessage(), PhotoServiceErrorType.VALIDATION_FAILED);
         }
         log.debug("Flickr Response [{}]", response);
         return response;
@@ -327,11 +327,60 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
     }
 
     private PhotoServiceErrorType flickrErrorType(FlickrException e) {
-        String message = e.getErrorMessage();
-        if (message != null && message.equalsIgnoreCase("Photoset not found")) {
+        String code = e.getErrorCode();
+        String message = normalize(e.getErrorMessage());
+        if (message.contains("photoset not found")) {
             return PhotoServiceErrorType.ALBUM_NOT_FOUND;
         }
+        if (message.contains("primary") && message.contains("not found")) {
+            return PhotoServiceErrorType.PRIMARY_PHOTO_NOT_FOUND;
+        }
+        if (message.contains("photo not found")) {
+            return PhotoServiceErrorType.PHOTO_NOT_FOUND;
+        }
+        if ("100".equals(code) || message.contains("invalid api key")) {
+            return PhotoServiceErrorType.INVALID_API_KEY;
+        }
+        if (Set.of("95", "96", "97", "98").contains(code) || message.contains("auth token") || message.contains("signature")) {
+            return PhotoServiceErrorType.AUTHENTICATION_FAILED;
+        }
+        if ("99".equals(code) || message.contains("permission") || message.contains("not logged in")) {
+            return PhotoServiceErrorType.AUTHORIZATION_FAILED;
+        }
+        if ("105".equals(code) || message.contains("service unavailable") || message.contains("temporarily unavailable")) {
+            return PhotoServiceErrorType.SERVICE_UNAVAILABLE;
+        }
+        if (message.contains("rate limit") || message.contains("throttle")) {
+            return PhotoServiceErrorType.RATE_LIMITED;
+        }
+        if (message.contains("network") || message.contains("timeout") || message.contains("timed out")) {
+            return PhotoServiceErrorType.NETWORK_ERROR;
+        }
+        if ("106".equals(code) || message.contains("write failed") || message.contains("write operation")) {
+            return PhotoServiceErrorType.WRITE_FAILED;
+        }
+        if (message.contains("file too large")) {
+            return PhotoServiceErrorType.FILE_TOO_LARGE;
+        }
+        if (message.contains("upload limit")) {
+            return PhotoServiceErrorType.UPLOAD_LIMIT_EXCEEDED;
+        }
+        if (message.contains("duplicate")) {
+            return PhotoServiceErrorType.DUPLICATE_UPLOAD;
+        }
+        if (message.contains("empty") && message.contains("photo")) {
+            return PhotoServiceErrorType.EMPTY_PHOTO_LIST;
+        }
+        if (message.contains("invalid")) {
+            return PhotoServiceErrorType.VALIDATION_FAILED;
+        }
         return PhotoServiceErrorType.UNKNOWN;
+    }
+
+    private String normalize(String message) {
+        return Optional.ofNullable(message)
+                .map(value -> value.trim().toLowerCase())
+                .orElse("");
     }
 
     @FunctionalInterface

--- a/src/main/java/io/legohunter/imaging/model/PhotoServiceErrorType.java
+++ b/src/main/java/io/legohunter/imaging/model/PhotoServiceErrorType.java
@@ -1,20 +1,30 @@
 package io.legohunter.imaging.model;
 
 public enum PhotoServiceErrorType {
-    ALBUM_NOT_FOUND,
-    PHOTO_NOT_FOUND,
-    PRIMARY_PHOTO_NOT_FOUND,
-    AUTHENTICATION_FAILED,
-    AUTHORIZATION_FAILED,
-    INVALID_API_KEY,
-    SERVICE_UNAVAILABLE,
-    RATE_LIMITED,
-    NETWORK_ERROR,
-    WRITE_FAILED,
-    VALIDATION_FAILED,
-    EMPTY_PHOTO_LIST,
-    DUPLICATE_UPLOAD,
-    UPLOAD_LIMIT_EXCEEDED,
-    FILE_TOO_LARGE,
-    UNKNOWN
+    ALBUM_NOT_FOUND(false),
+    PHOTO_NOT_FOUND(false),
+    PRIMARY_PHOTO_NOT_FOUND(false),
+    AUTHENTICATION_FAILED(false),
+    AUTHORIZATION_FAILED(false),
+    INVALID_API_KEY(false),
+    SERVICE_UNAVAILABLE(true),
+    RATE_LIMITED(true),
+    NETWORK_ERROR(true),
+    WRITE_FAILED(true),
+    VALIDATION_FAILED(false),
+    EMPTY_PHOTO_LIST(false),
+    DUPLICATE_UPLOAD(false),
+    UPLOAD_LIMIT_EXCEEDED(false),
+    FILE_TOO_LARGE(false),
+    UNKNOWN(false);
+
+    private final boolean retryable;
+
+    PhotoServiceErrorType(boolean retryable) {
+        this.retryable = retryable;
+    }
+
+    public boolean isRetryable() {
+        return retryable;
+    }
 }

--- a/src/main/java/io/legohunter/imaging/model/PhotoServiceResponse.java
+++ b/src/main/java/io/legohunter/imaging/model/PhotoServiceResponse.java
@@ -11,4 +11,8 @@ public interface PhotoServiceResponse<T> extends Supplier<T>, Consumer<T> {
     default PhotoServiceErrorType errorType() {
         return PhotoServiceErrorType.UNKNOWN;
     }
+
+    default boolean isRetryable() {
+        return isError() && errorType().isRetryable();
+    }
 }

--- a/src/main/java/io/legohunter/imaging/service/sync/model/SyncActionResult.java
+++ b/src/main/java/io/legohunter/imaging/service/sync/model/SyncActionResult.java
@@ -18,6 +18,9 @@ public class SyncActionResult {
     private Integer responseCode;
     private String message;
     private PhotoServiceErrorType errorType;
+    private int attempts;
+    private boolean retried;
+    private boolean retryable;
     private LocalDateTime startedAt;
     private LocalDateTime finishedAt;
 

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -311,7 +311,7 @@ class FlickrPhotoServiceTest {
     @Test
     void listAlbums_mapsProviderError() throws Exception {
         when(photosetsInterface.getList("user-123", 0, 0, null))
-                .thenThrow(new FlickrException("99", "provider rejected album list"));
+                .thenThrow(new FlickrException("105", "Service unavailable"));
 
         PhotoServiceResponse<HostedAlbumPage> response = flickrPhotoService.listAlbums(new FlickrServiceRequest<>(
                 HostedAlbumSearchRequest.builder()
@@ -320,8 +320,10 @@ class FlickrPhotoServiceTest {
         ));
 
         assertThat(response.isError()).isTrue();
-        assertThat(response.responseCode()).isEqualTo(99);
-        assertThat(response.responseMessage()).isEqualTo("provider rejected album list");
+        assertThat(response.responseCode()).isEqualTo(105);
+        assertThat(response.responseMessage()).isEqualTo("Service unavailable");
+        assertThat(response.errorType()).isEqualTo(PhotoServiceErrorType.SERVICE_UNAVAILABLE);
+        assertThat(response.isRetryable()).isTrue();
     }
 
     @Test
@@ -449,6 +451,8 @@ class FlickrPhotoServiceTest {
         assertThat(response.isError()).isTrue();
         assertThat(response.responseCode()).isEqualTo(99);
         assertThat(response.responseMessage()).isEqualTo("Insufficient permissions");
+        assertThat(response.errorType()).isEqualTo(PhotoServiceErrorType.AUTHORIZATION_FAILED);
+        assertThat(response.isRetryable()).isFalse();
     }
 
     @Test
@@ -460,7 +464,39 @@ class FlickrPhotoServiceTest {
         assertThat(response.isError()).isTrue();
         assertThat(response.responseCode()).isEqualTo(-1);
         assertThat(response.responseMessage()).contains("missing.jpg");
+        assertThat(response.errorType()).isEqualTo(PhotoServiceErrorType.VALIDATION_FAILED);
+        assertThat(response.isRetryable()).isFalse();
         verifyNoInteractions(uploader);
+    }
+
+    @Test
+    void flickrException_mapsPhotoNotFoundErrors() throws Exception {
+        when(photosInterface.getPhoto("missing-photo"))
+                .thenThrow(new FlickrException("1", "Photo not found"));
+
+        PhotoServiceResponse<HostedPhoto> response = flickrPhotoService.getPhoto(new FlickrServiceRequest<>("missing-photo"));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.errorType()).isEqualTo(PhotoServiceErrorType.PHOTO_NOT_FOUND);
+        assertThat(response.isRetryable()).isFalse();
+    }
+
+    @Test
+    void flickrException_mapsWriteFailureAsRetryable() throws Exception {
+        HostedAlbumMetadataUpdate request = HostedAlbumMetadataUpdate.builder()
+                .albumId("album-123")
+                .title("title")
+                .description("description")
+                .build();
+        doThrow(new FlickrException("106", "Write operation failed"))
+                .when(photosetsInterface)
+                .editMeta("album-123", "title", "description");
+
+        PhotoServiceResponse<Void> response = flickrPhotoService.updateAlbumMetadata(new FlickrServiceRequest<>(request));
+
+        assertThat(response.isError()).isTrue();
+        assertThat(response.errorType()).isEqualTo(PhotoServiceErrorType.WRITE_FAILED);
+        assertThat(response.isRetryable()).isTrue();
     }
 
     private PhotoMetaDataV1 primaryPhoto(String photoId) {

--- a/src/test/java/io/legohunter/imaging/service/sync/model/SyncReportTest.java
+++ b/src/test/java/io/legohunter/imaging/service/sync/model/SyncReportTest.java
@@ -59,6 +59,35 @@ class SyncReportTest {
         assertThat(result.getErrorType()).isNull();
     }
 
+    @Test
+    void actionResultCanExposeRetryAttempts() {
+        SyncActionResult result = SyncActionResult.builder()
+                .actionId("action-1")
+                .type(SyncActionType.UPDATE_ALBUM_METADATA)
+                .status(SyncActionStatus.FAILED)
+                .errorType(PhotoServiceErrorType.SERVICE_UNAVAILABLE)
+                .attempts(3)
+                .retried(true)
+                .retryable(true)
+                .build();
+
+        assertThat(result.getErrorType()).isEqualTo(PhotoServiceErrorType.SERVICE_UNAVAILABLE);
+        assertThat(result.getAttempts()).isEqualTo(3);
+        assertThat(result.isRetried()).isTrue();
+        assertThat(result.isRetryable()).isTrue();
+    }
+
+    @Test
+    void transientErrorTypesAreRetryable() {
+        assertThat(PhotoServiceErrorType.SERVICE_UNAVAILABLE.isRetryable()).isTrue();
+        assertThat(PhotoServiceErrorType.RATE_LIMITED.isRetryable()).isTrue();
+        assertThat(PhotoServiceErrorType.NETWORK_ERROR.isRetryable()).isTrue();
+        assertThat(PhotoServiceErrorType.WRITE_FAILED.isRetryable()).isTrue();
+        assertThat(PhotoServiceErrorType.AUTHENTICATION_FAILED.isRetryable()).isFalse();
+        assertThat(PhotoServiceErrorType.ALBUM_NOT_FOUND.isRetryable()).isFalse();
+        assertThat(PhotoServiceErrorType.VALIDATION_FAILED.isRetryable()).isFalse();
+    }
+
     private SyncActionResult result(String actionId, SyncActionStatus status) {
         return SyncActionResult.builder()
                 .actionId(actionId)


### PR DESCRIPTION
## Summary
- Marks transient image-hosting error types as retryable.
- Exposes retryability through PhotoServiceResponse.
- Maps common Flickr failures to actionable PhotoServiceErrorType values instead of UNKNOWN.
- Adds retry attempt fields to SyncActionResult so apply reports can expose bounded retry behavior.
- Adds tests for Flickr error mapping, retryability, and SyncActionResult retry metadata.

## Error handling behavior
- Retryable: SERVICE_UNAVAILABLE, RATE_LIMITED, NETWORK_ERROR, WRITE_FAILED.
- Not retryable: auth/authz, invalid API key, not found, validation, duplicate upload, upload limit, file too large, unknown.

## Verification
- mvn test: 133 tests passed

## Review/Merge Order
- Merge this lego-imaging PR before the matching lego-data-ingress PR on branch feature/flickr-phase3-pr9-retry-errors, because data-ingress consumes the shared retry/error model fields.