### PR TITLE
Flickr Phase 3 PR10: Add upload publishing metadata

### DIFF
--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -25,6 +25,7 @@ import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
+import io.legohunter.imaging.model.HostedPhotoUploadMetadata;
 import io.legohunter.imaging.model.HostedPhotoPage;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceErrorType;
@@ -267,20 +268,43 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
     }
 
     private UploadMetaData uploadMetaData(PhotoMetaDataV1 photoMetaData) {
+        HostedPhotoUploadMetadata metadata = Optional.ofNullable(photoMetaData.getUploadMetadata())
+                .orElseGet(() -> HostedPhotoUploadMetadata.builder().build());
         UploadMetaData uploadMetaData = new UploadMetaData();
         uploadMetaData.setAsync(SYNC_UPLOAD);
         uploadMetaData.setContentType(Flickr.CONTENTTYPE_PHOTO);
-        uploadMetaData.setFamilyFlag(false);
+        uploadMetaData.setFamilyFlag(Boolean.TRUE.equals(metadata.getFamilyFlag()));
         uploadMetaData.setFilemimetype(JPEG_MIME_TYPE);
         uploadMetaData.setFilename(photoMetaData.getFilename().toString());
-        uploadMetaData.setDescription("Description [" + photoMetaData.getFilename() + "]");
-        uploadMetaData.setFriendFlag(false);
-        uploadMetaData.setHidden(false);
-        uploadMetaData.setPublicFlag(true);
-        uploadMetaData.setSafetyLevel(Flickr.SAFETYLEVEL_SAFE);
-        uploadMetaData.setTags(Collections.emptyList());
-        uploadMetaData.setTitle("Title [" + photoMetaData.getFilename() + "]");
+        uploadMetaData.setDescription(textOrEmpty(metadata.getDescription()));
+        uploadMetaData.setFriendFlag(Boolean.TRUE.equals(metadata.getFriendFlag()));
+        uploadMetaData.setHidden(Boolean.TRUE.equals(metadata.getHidden()));
+        uploadMetaData.setPublicFlag(!Boolean.FALSE.equals(metadata.getPublicFlag()));
+        uploadMetaData.setSafetyLevel(flickrSafetyLevel(metadata.getSafetyLevel()));
+        uploadMetaData.setTags(metadata.getTags());
+        uploadMetaData.setTitle(textOrDefault(metadata.getTitle(), photoMetaData.getFilename().toString()));
         return uploadMetaData;
+    }
+
+    private String flickrSafetyLevel(String safetyLevel) {
+        return Optional.ofNullable(safetyLevel)
+                .map(value -> switch (value.trim().toLowerCase()) {
+                    case "moderate" -> Flickr.SAFETYLEVEL_MODERATE;
+                    case "restricted" -> Flickr.SAFETYLEVEL_RESTRICTED;
+                    case "safe" -> Flickr.SAFETYLEVEL_SAFE;
+                    default -> value;
+                })
+                .orElse(Flickr.SAFETYLEVEL_SAFE);
+    }
+
+    private String textOrDefault(String value, String defaultValue) {
+        return Optional.ofNullable(value)
+                .filter(text -> !text.isBlank())
+                .orElse(defaultValue);
+    }
+
+    private String textOrEmpty(String value) {
+        return textOrDefault(value, "");
     }
 
     private HostedAlbum toHostedAlbum(Photoset photoset) {

--- a/src/main/java/io/legohunter/imaging/model/HostedPhotoUploadMetadata.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedPhotoUploadMetadata.java
@@ -1,0 +1,29 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Data
+@Builder
+public class HostedPhotoUploadMetadata {
+    private String title;
+    private String description;
+
+    @Singular
+    private List<String> tags;
+
+    private Boolean publicFlag;
+    private Boolean friendFlag;
+    private Boolean familyFlag;
+    private Boolean hidden;
+    private String safetyLevel;
+
+    public List<String> getTags() {
+        return Optional.ofNullable(tags).orElse(Collections.emptyList());
+    }
+}

--- a/src/main/java/io/legohunter/imaging/model/PhotoMetaDataV1.java
+++ b/src/main/java/io/legohunter/imaging/model/PhotoMetaDataV1.java
@@ -49,6 +49,9 @@ public class PhotoMetaDataV1 {
     private boolean primary;
     private boolean changed;
 
+    @JsonIgnore
+    private HostedPhotoUploadMetadata uploadMetadata;
+
     @JsonProperty("filename")
     public String getFilenameString() {
         return filename.getFileName().toString();

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -23,6 +23,7 @@ import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.HostedAlbumMetadataUpdate;
 import io.legohunter.imaging.model.HostedPhoto;
 import io.legohunter.imaging.model.HostedPhotoMetadataUpdate;
+import io.legohunter.imaging.model.HostedPhotoUploadMetadata;
 import io.legohunter.imaging.model.HostedPhotoPage;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.model.PhotoServiceErrorType;
@@ -96,6 +97,40 @@ class FlickrPhotoServiceTest {
         assertThat(metadata.isHidden()).isFalse();
         assertThat(metadata.getSafetyLevel()).isEqualTo(Flickr.SAFETYLEVEL_SAFE);
         assertThat(metadata.getTags()).isEmpty();
+    }
+
+    @Test
+    void uploadPhoto_usesSuppliedPublishingMetadata(@TempDir Path tempDir) throws Exception {
+        Path photoPath = tempDir.resolve("photo.jpg");
+        Files.write(photoPath, new byte[]{1, 2, 3});
+        when(uploader.upload(any(byte[].class), any(UploadMetaData.class))).thenReturn("photo-123");
+        PhotoMetaDataV1 photoMetaData = new PhotoMetaDataV1(photoPath);
+        photoMetaData.setUploadMetadata(HostedPhotoUploadMetadata.builder()
+                .title("Custom title")
+                .description("Custom description")
+                .tag("lego")
+                .tag("sealed")
+                .publicFlag(false)
+                .friendFlag(true)
+                .familyFlag(true)
+                .hidden(true)
+                .safetyLevel("restricted")
+                .build());
+
+        PhotoServiceResponse<String> response = flickrPhotoService.uploadPhoto(new FlickrServiceRequest<>(photoMetaData));
+
+        assertThat(response.isError()).isFalse();
+        org.mockito.ArgumentCaptor<UploadMetaData> metadataCaptor = org.mockito.ArgumentCaptor.forClass(UploadMetaData.class);
+        verify(uploader).upload(eq(new byte[]{1, 2, 3}), metadataCaptor.capture());
+        UploadMetaData metadata = metadataCaptor.getValue();
+        assertThat(metadata.getTitle()).isEqualTo("Custom title");
+        assertThat(metadata.getDescription()).isEqualTo("Custom description");
+        assertThat(metadata.getTags()).containsExactly("lego", "sealed");
+        assertThat(metadata.isPublicFlag()).isFalse();
+        assertThat(metadata.isFriendFlag()).isTrue();
+        assertThat(metadata.isFamilyFlag()).isTrue();
+        assertThat(metadata.isHidden()).isTrue();
+        assertThat(metadata.getSafetyLevel()).isEqualTo(Flickr.SAFETYLEVEL_RESTRICTED);
     }
 
     @Test


### PR DESCRIPTION
Summary:
- Add HostedPhotoUploadMetadata as the request-time carrier for photo publishing options.
- Update Flickr upload mapping to use supplied title, description, tags, visibility flags, hidden/search behavior, and safety level instead of placeholder upload metadata.
- Keep upload publishing metadata out of legacy AlbumManifest JSON serialization.

Validation:
- mvn clean install