### PR TITLE
Flickr Phase 3 PR13: Contain legacy album manifests

### DIFF
--- a/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
+++ b/src/main/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceImpl.java
@@ -16,8 +16,8 @@ import com.flickr4java.flickr.uploader.UploadMetaData;
 import io.legohunter.imaging.exception.LegoImagingException;
 import io.legohunter.imaging.flickr.api.FlickrPhotoService;
 import io.legohunter.imaging.flickr.model.FlickrServiceResponse;
-import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumCreateRequest;
 import io.legohunter.imaging.model.HostedAlbumPage;
 import io.legohunter.imaging.model.HostedAlbumPhotoSearchRequest;
 import io.legohunter.imaging.model.HostedAlbumSearchRequest;
@@ -105,18 +105,20 @@ public class FlickrPhotoServiceImpl implements FlickrPhotoService {
     }
 
     @Override
-    public PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<AlbumManifest> request) throws LegoImagingException {
+    public PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<HostedAlbumCreateRequest> request) throws LegoImagingException {
         PhotoServiceResponse<HostedAlbum> response;
-        AlbumManifest albumManifest = request.get();
+        HostedAlbumCreateRequest createRequest = request.get();
         try {
-            if (albumManifest.getPhotos().size() < 1) {
+            if (createRequest.getPhotoIds().isEmpty()) {
                 throw new LegoImagingException("Cannot create a Flickr Album that has no photos");
             }
-            PhotoMetaDataV1 primaryPhoto = albumManifest.getPrimaryPhoto();
+            if (textOrDefault(createRequest.getPrimaryPhotoId(), "").isBlank()) {
+                throw new LegoImagingException("Cannot create a Flickr Album without a primary photo id");
+            }
             Photoset photoset = withFlickrAuth(() -> photosetsInterface.create(
-                    albumManifest.getTitle(),
-                    albumManifest.getDescription(),
-                    primaryPhoto.getPhotoId()));
+                    createRequest.getTitle(),
+                    createRequest.getDescription(),
+                    createRequest.getPrimaryPhotoId()));
             response = new FlickrServiceResponse<>(HostedAlbum.builder()
                     .id(photoset.getId())
                     .url(photoset.getUrl())

--- a/src/main/java/io/legohunter/imaging/flickr/model/CreatePhotoSetRequest.java
+++ b/src/main/java/io/legohunter/imaging/flickr/model/CreatePhotoSetRequest.java
@@ -1,9 +1,9 @@
 package io.legohunter.imaging.flickr.model;
 
-import io.legohunter.imaging.model.AlbumManifest;
+import io.legohunter.imaging.model.HostedAlbumCreateRequest;
 
-public class CreatePhotoSetRequest extends FlickrServiceRequest<AlbumManifest> {
-    public CreatePhotoSetRequest(AlbumManifest albumManifest) {
-        super(albumManifest);
+public class CreatePhotoSetRequest extends FlickrServiceRequest<HostedAlbumCreateRequest> {
+    public CreatePhotoSetRequest(HostedAlbumCreateRequest request) {
+        super(request);
     }
 }

--- a/src/main/java/io/legohunter/imaging/model/AlbumManifest.java
+++ b/src/main/java/io/legohunter/imaging/model/AlbumManifest.java
@@ -26,11 +26,16 @@ import java.util.stream.Collectors;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+/**
+ * Legacy gen-1 local JSON manifest model.
+ * Gen-2 image hosting sync should use DB/S3-backed hosted models instead.
+ */
 @Getter
 @Setter
 @ToString
 @JsonInclude(Include.NON_NULL)
 @Slf4j
+@Deprecated(since = "1.4.0", forRemoval = false)
 public class AlbumManifest {
     private String photosetId;
     private String title;

--- a/src/main/java/io/legohunter/imaging/model/HostedAlbumCreateRequest.java
+++ b/src/main/java/io/legohunter/imaging/model/HostedAlbumCreateRequest.java
@@ -1,0 +1,24 @@
+package io.legohunter.imaging.model;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Data
+@Builder
+public class HostedAlbumCreateRequest {
+    private String title;
+    private String description;
+    private String primaryPhotoId;
+
+    @Singular
+    private List<String> photoIds;
+
+    public List<String> getPhotoIds() {
+        return Optional.ofNullable(photoIds).orElse(Collections.emptyList());
+    }
+}

--- a/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
+++ b/src/main/java/io/legohunter/imaging/service/hosting/api/ImageHostingService.java
@@ -1,7 +1,7 @@
 package io.legohunter.imaging.service.hosting.api;
 
-import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumCreateRequest;
 import io.legohunter.imaging.model.HostedAlbumPage;
 import io.legohunter.imaging.model.HostedAlbumPhotoSearchRequest;
 import io.legohunter.imaging.model.HostedAlbumSearchRequest;
@@ -21,7 +21,7 @@ public interface ImageHostingService {
 
     PhotoServiceResponse<Void> deletePhoto(PhotoServiceRequest<String> request);
 
-    PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<AlbumManifest> request);
+    PhotoServiceResponse<HostedAlbum> createAlbum(PhotoServiceRequest<HostedAlbumCreateRequest> request);
 
     PhotoServiceResponse<HostedAlbumPage> listAlbums(PhotoServiceRequest<HostedAlbumSearchRequest> request);
 

--- a/src/main/java/io/legohunter/imaging/service/upload/impl/PhotoServiceUploadManagerImpl.java
+++ b/src/main/java/io/legohunter/imaging/service/upload/impl/PhotoServiceUploadManagerImpl.java
@@ -4,6 +4,7 @@ import io.legohunter.imaging.config.LegoImagingProperties;
 import io.legohunter.imaging.exception.LegoImagingException;
 import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumCreateRequest;
 import io.legohunter.imaging.model.HostedAlbumMembershipRequest;
 import io.legohunter.imaging.model.PhotoMetaDataV1;
 import io.legohunter.imaging.bitly.model.bitly.ShortenRequest;
@@ -86,7 +87,7 @@ public class PhotoServiceUploadManagerImpl implements PhotoServiceUploadManager 
             String photosetId = Optional.ofNullable(a.getPhotosetId())
                     .orElseGet(() -> {
                         try {
-                            PhotoServiceResponse<HostedAlbum> response = imageHostingService.createAlbum(new SimplePhotoServiceRequest<>(a));
+                            PhotoServiceResponse<HostedAlbum> response = imageHostingService.createAlbum(new SimplePhotoServiceRequest<>(toCreateRequest(a)));
                             assertSuccess(response);
                             HostedAlbum album = response.get();
                             log.info("Created Photoset [{}] with primary photo id [{}] - filename [{}]", album, primaryPhotoId, primaryPhoto.getFilename());
@@ -126,5 +127,15 @@ public class PhotoServiceUploadManagerImpl implements PhotoServiceUploadManager 
         if (response.isError()) {
             throw new LegoImagingException(response.responseMessage());
         }
+    }
+
+    private HostedAlbumCreateRequest toCreateRequest(AlbumManifest albumManifest) {
+        PhotoMetaDataV1 primaryPhoto = albumManifest.getPrimaryPhoto();
+        return HostedAlbumCreateRequest.builder()
+                .title(albumManifest.getTitle())
+                .description(albumManifest.getDescription())
+                .primaryPhotoId(primaryPhoto.getPhotoId())
+                .photoIds(albumManifest.getPhotoIds())
+                .build();
     }
 }

--- a/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
+++ b/src/test/java/io/legohunter/imaging/flickr/impl/FlickrPhotoServiceTest.java
@@ -14,8 +14,8 @@ import com.flickr4java.flickr.photosets.PhotosetsInterface;
 import com.flickr4java.flickr.uploader.IUploader;
 import com.flickr4java.flickr.uploader.UploadMetaData;
 import io.legohunter.imaging.flickr.model.FlickrServiceRequest;
-import io.legohunter.imaging.model.AlbumManifest;
 import io.legohunter.imaging.model.HostedAlbum;
+import io.legohunter.imaging.model.HostedAlbumCreateRequest;
 import io.legohunter.imaging.model.HostedAlbumPage;
 import io.legohunter.imaging.model.HostedAlbumPhotoSearchRequest;
 import io.legohunter.imaging.model.HostedAlbumSearchRequest;
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -84,7 +85,7 @@ class FlickrPhotoServiceTest {
         assertThat(response.isError()).isFalse();
         assertThat(response.responseCode()).isZero();
         assertThat(response.get()).isEqualTo("photo-123");
-        org.mockito.ArgumentCaptor<UploadMetaData> metadataCaptor = org.mockito.ArgumentCaptor.forClass(UploadMetaData.class);
+        ArgumentCaptor<UploadMetaData> metadataCaptor = ArgumentCaptor.forClass(UploadMetaData.class);
         verify(uploader).upload(eq(new byte[]{1, 2, 3}), metadataCaptor.capture());
         UploadMetaData metadata = metadataCaptor.getValue();
         assertThat(metadata.isAsync()).isFalse();
@@ -120,7 +121,7 @@ class FlickrPhotoServiceTest {
         PhotoServiceResponse<String> response = flickrPhotoService.uploadPhoto(new FlickrServiceRequest<>(photoMetaData));
 
         assertThat(response.isError()).isFalse();
-        org.mockito.ArgumentCaptor<UploadMetaData> metadataCaptor = org.mockito.ArgumentCaptor.forClass(UploadMetaData.class);
+        ArgumentCaptor<UploadMetaData> metadataCaptor = ArgumentCaptor.forClass(UploadMetaData.class);
         verify(uploader).upload(eq(new byte[]{1, 2, 3}), metadataCaptor.capture());
         UploadMetaData metadata = metadataCaptor.getValue();
         assertThat(metadata.getTitle()).isEqualTo("Custom title");
@@ -191,18 +192,20 @@ class FlickrPhotoServiceTest {
     }
 
     @Test
-    void createAlbum_createsPhotosetFromAlbumManifest() throws Exception {
+    void createAlbum_createsPhotosetFromHostedAlbumCreateRequest() throws Exception {
         Photoset photoset = new Photoset();
         photoset.setId("album-123");
         photoset.setUrl("https://www.flickr.com/photos/user/albums/album-123");
         when(photosetsInterface.create("album title", "album description", "primary-photo")).thenReturn(photoset);
 
-        AlbumManifest albumManifest = new AlbumManifest();
-        albumManifest.setTitle("album title");
-        albumManifest.setDescription("album description");
-        albumManifest.setPhotos(List.of(primaryPhoto("primary-photo")));
+        HostedAlbumCreateRequest request = HostedAlbumCreateRequest.builder()
+                .title("album title")
+                .description("album description")
+                .primaryPhotoId("primary-photo")
+                .photoId("primary-photo")
+                .build();
 
-        PhotoServiceResponse<HostedAlbum> response = flickrPhotoService.createAlbum(new FlickrServiceRequest<>(albumManifest));
+        PhotoServiceResponse<HostedAlbum> response = flickrPhotoService.createAlbum(new FlickrServiceRequest<>(request));
 
         assertThat(response.isError()).isFalse();
         assertThat(response.get().getId()).isEqualTo("album-123");
@@ -534,10 +537,4 @@ class FlickrPhotoServiceTest {
         assertThat(response.isRetryable()).isTrue();
     }
 
-    private PhotoMetaDataV1 primaryPhoto(String photoId) {
-        PhotoMetaDataV1 photoMetaData = new PhotoMetaDataV1(Path.of("photo.jpg"));
-        photoMetaData.setPhotoId(photoId);
-        photoMetaData.setPrimary(true);
-        return photoMetaData;
-    }
 }


### PR DESCRIPTION
## Summary
- Introduce HostedAlbumCreateRequest as the manifest-free album creation contract for image-hosting providers.
- Update Flickr create-album handling to use title, description, primaryPhotoId, and photoIds directly instead of AlbumManifest.
- Keep gen-1 AlbumManifest support only inside legacy upload/album-manager paths by adapting AlbumManifest to HostedAlbumCreateRequest at the boundary.
- Mark AlbumManifest as a legacy gen-1 JSON manifest model.

## Verification
- mvn clean install